### PR TITLE
[codex] Use live follow totals on profile headers

### DIFF
--- a/founder-sprint/src/actions/profile.ts
+++ b/founder-sprint/src/actions/profile.ts
@@ -300,77 +300,79 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
     ? undefined
     : { in: viewerBatchIds };
 
-  const profile = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      id: true,
-      email: true,
-      name: true,
-      profileImage: true,
-      jobTitle: true,
-      company: true,
-      bio: true,
-      headline: true,
-      followerCount: true,
-      followingCount: true,
-      location: true,
-      linkedinUrl: true,
-      twitterUrl: true,
-      websiteUrl: true,
-      timezone: true,
-      userBatches: {
-        where: {
-          status: "active",
-          ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
-        },
-        select: {
-          batchId: true,
-          role: true,
-          batch: { select: { name: true } },
-        },
-      },
-      groupMembers: {
-        where: {
-          group: {
+  const [profile, liveFollowerCount, liveFollowingCount] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        profileImage: true,
+        jobTitle: true,
+        company: true,
+        bio: true,
+        headline: true,
+        location: true,
+        linkedinUrl: true,
+        twitterUrl: true,
+        websiteUrl: true,
+        timezone: true,
+        userBatches: {
+          where: {
+            status: "active",
             ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
           },
-        },
-        select: { group: { select: { id: true, name: true } } },
-      },
-      officeHourSlots: {
-        where: {
-          status: "available",
-          startTime: { gte: new Date() },
-          ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
-        },
-        select: { id: true, startTime: true, endTime: true, status: true },
-        orderBy: { startTime: "asc" },
-        take: 5,
-      },
-      experiences: {
-        orderBy: [{ isCurrent: "desc" }, { startDate: "desc" }],
-      },
-      education: {
-        orderBy: [
-          { endYear: { sort: "desc", nulls: "first" } },
-          { startYear: "desc" },
-        ],
-      },
-      companyMemberships: {
-        include: {
-          company: {
-            select: {
-              id: true,
-              name: true,
-              slug: true,
-              logoUrl: true,
-            },
+          select: {
+            batchId: true,
+            role: true,
+            batch: { select: { name: true } },
           },
         },
-        orderBy: [{ isCurrent: "desc" }, { createdAt: "desc" }],
+        groupMembers: {
+          where: {
+            group: {
+              ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
+            },
+          },
+          select: { group: { select: { id: true, name: true } } },
+        },
+        officeHourSlots: {
+          where: {
+            status: "available",
+            startTime: { gte: new Date() },
+            ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
+          },
+          select: { id: true, startTime: true, endTime: true, status: true },
+          orderBy: { startTime: "asc" },
+          take: 5,
+        },
+        experiences: {
+          orderBy: [{ isCurrent: "desc" }, { startDate: "desc" }],
+        },
+        education: {
+          orderBy: [
+            { endYear: { sort: "desc", nulls: "first" } },
+            { startYear: "desc" },
+          ],
+        },
+        companyMemberships: {
+          include: {
+            company: {
+              select: {
+                id: true,
+                name: true,
+                slug: true,
+                logoUrl: true,
+              },
+            },
+          },
+          orderBy: [{ isCurrent: "desc" }, { createdAt: "desc" }],
+        },
       },
-    },
-  });
+    }),
+    prisma.userFollow.count({ where: { followingId: userId } }),
+    prisma.userFollow.count({ where: { followerId: userId } }),
+  ]);
 
   if (!profile) return { success: false, error: "User not found" };
 
@@ -393,8 +395,8 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
         status: item.status,
       })),
       headline: profile.headline,
-      followerCount: profile.followerCount,
-      followingCount: profile.followingCount,
+      followerCount: liveFollowerCount,
+      followingCount: liveFollowingCount,
       location: profile.location,
       linkedinUrl: profile.linkedinUrl,
       twitterUrl: profile.twitterUrl,

--- a/founder-sprint/src/actions/profile.ts
+++ b/founder-sprint/src/actions/profile.ts
@@ -300,79 +300,81 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
     ? undefined
     : { in: viewerBatchIds };
 
-  const [profile, liveFollowerCount, liveFollowingCount] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-        profileImage: true,
-        jobTitle: true,
-        company: true,
-        bio: true,
-        headline: true,
-        location: true,
-        linkedinUrl: true,
-        twitterUrl: true,
-        websiteUrl: true,
-        timezone: true,
-        userBatches: {
-          where: {
-            status: "active",
-            ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
-          },
-          select: {
-            batchId: true,
-            role: true,
-            batch: { select: { name: true } },
-          },
-        },
-        groupMembers: {
-          where: {
-            group: {
-              ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
-            },
-          },
-          select: { group: { select: { id: true, name: true } } },
-        },
-        officeHourSlots: {
-          where: {
-            status: "available",
-            startTime: { gte: new Date() },
-            ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
-          },
-          select: { id: true, startTime: true, endTime: true, status: true },
-          orderBy: { startTime: "asc" },
-          take: 5,
-        },
-        experiences: {
-          orderBy: [{ isCurrent: "desc" }, { startDate: "desc" }],
-        },
-        education: {
-          orderBy: [
-            { endYear: { sort: "desc", nulls: "first" } },
-            { startYear: "desc" },
-          ],
-        },
-        companyMemberships: {
-          include: {
-            company: {
-              select: {
-                id: true,
-                name: true,
-                slug: true,
-                logoUrl: true,
-              },
-            },
-          },
-          orderBy: [{ isCurrent: "desc" }, { createdAt: "desc" }],
+  const profile = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      profileImage: true,
+      jobTitle: true,
+      company: true,
+      bio: true,
+      headline: true,
+      location: true,
+      linkedinUrl: true,
+      twitterUrl: true,
+      websiteUrl: true,
+      timezone: true,
+      _count: {
+        select: {
+          followers: true,
+          following: true,
         },
       },
-    }),
-    prisma.userFollow.count({ where: { followingId: userId } }),
-    prisma.userFollow.count({ where: { followerId: userId } }),
-  ]);
+      userBatches: {
+        where: {
+          status: "active",
+          ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
+        },
+        select: {
+          batchId: true,
+          role: true,
+          batch: { select: { name: true } },
+        },
+      },
+      groupMembers: {
+        where: {
+          group: {
+            ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
+          },
+        },
+        select: { group: { select: { id: true, name: true } } },
+      },
+      officeHourSlots: {
+        where: {
+          status: "available",
+          startTime: { gte: new Date() },
+          ...(accessibleBatchIds ? { batchId: accessibleBatchIds } : {}),
+        },
+        select: { id: true, startTime: true, endTime: true, status: true },
+        orderBy: { startTime: "asc" },
+        take: 5,
+      },
+      experiences: {
+        orderBy: [{ isCurrent: "desc" }, { startDate: "desc" }],
+      },
+      education: {
+        orderBy: [
+          { endYear: { sort: "desc", nulls: "first" } },
+          { startYear: "desc" },
+        ],
+      },
+      companyMemberships: {
+        include: {
+          company: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              logoUrl: true,
+            },
+          },
+        },
+        orderBy: [{ isCurrent: "desc" }, { createdAt: "desc" }],
+      },
+    },
+  });
 
   if (!profile) return { success: false, error: "User not found" };
 
@@ -395,8 +397,8 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
         status: item.status,
       })),
       headline: profile.headline,
-      followerCount: liveFollowerCount,
-      followingCount: liveFollowingCount,
+      followerCount: profile._count.followers,
+      followingCount: profile._count.following,
       location: profile.location,
       linkedinUrl: profile.linkedinUrl,
       twitterUrl: profile.twitterUrl,


### PR DESCRIPTION
## Summary
- Change profile header follower/following totals to use live `user_follows` counts.
- Avoid showing stale denormalized `users.follower_count` / `users.following_count` values on profile pages.

## Why
Some users have stale stored counters. For example, Matthew has `users.following_count = 5`, but only 3 actual rows in `user_follows` where he is the follower. The profile header was reading the stale stored value while the Following tab was built from the actual relation table, causing the mismatch.

## Validation
- `npx eslint 'src/actions/profile.ts' 'src/components/profile/ProfileIcons.tsx' 'src/app/(dashboard)/profile/[userId]/ProfileClient.tsx'`
  - Result: 0 errors; 2 pre-existing `<img>` warnings in `ProfileClient.tsx`.
- Read-only DB check confirmed Matthew has stored following count 5 and live following count 3; after this code path change the profile response uses the live count.

## Notes
- This does not mutate database rows.
- Stored counters may still be stale for other non-profile use cases; a separate reconciliation job/trigger would be appropriate if those counters need to remain authoritative elsewhere.
