### PR TITLE
[codex] Improve admin directory defaults and share feedback

### DIFF
--- a/founder-sprint/src/actions/user-management.ts
+++ b/founder-sprint/src/actions/user-management.ts
@@ -776,7 +776,7 @@ export async function removeUserFromBatch(
   return { success: true, data: undefined };
 }
 
-export async function cancelInvite(userId: string): Promise<ActionResult> {
+export async function cancelInvite(userId: string, batchId: string): Promise<ActionResult> {
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
@@ -786,23 +786,22 @@ export async function cancelInvite(userId: string): Promise<ActionResult> {
     return { success: false, error: "Unauthorized" };
   }
 
-  const targetUser = await prisma.user.findUnique({
-    where: { id: userId },
-    include: { userBatches: true },
+  const targetMembership = await prisma.userBatch.findUnique({
+    where: { userId_batchId: { userId, batchId } },
+    select: { status: true },
   });
 
-  if (!targetUser) {
-    return { success: false, error: "User not found" };
+  if (!targetMembership) {
+    return { success: false, error: "Invite not found" };
   }
 
-  const hasActiveStatus = targetUser.userBatches.some((ub) => ub.status === "active");
-  if (hasActiveStatus) {
-    return { success: false, error: "Cannot cancel invite for active user" };
+  if (targetMembership.status !== "invited") {
+    return { success: false, error: "Only pending invites can be cancelled" };
   }
 
   await prisma.$transaction(async (tx) => {
-    await tx.invitationToken.deleteMany({ where: { userId } });
-    await tx.userBatch.deleteMany({ where: { userId, status: "invited" } });
+    await tx.invitationToken.deleteMany({ where: { userId, batchId } });
+    await tx.userBatch.deleteMany({ where: { userId, batchId, status: "invited" } });
 
     const hasAnyMembership = await tx.userBatch.count({ where: { userId } });
     if (hasAnyMembership === 0) {
@@ -815,9 +814,7 @@ export async function cancelInvite(userId: string): Promise<ActionResult> {
 
   revalidatePath("/admin/users");
   revalidatePath("/admin/batches");
-  targetUser.userBatches.forEach((userBatch) => {
-    revalidateTag(`batch-users-${userBatch.batchId}`);
-  });
+  revalidateTag(`batch-users-${batchId}`);
   revalidateTag("current-user");
   return { success: true, data: undefined };
 }
@@ -1221,6 +1218,26 @@ export async function getBatchUsers(batchId: string) {
     [`batch-users-${batchId}`],
     { revalidate: 60, tags: [`batch-users-${batchId}`] }
   )();
+
+  return batchUsers.map((membership) => ({
+    ...membership,
+    role: membership.user.role === "super_admin" ? "super_admin" : membership.role,
+    additionalRoles: membership.additionalRoles ?? [],
+    user: {
+      ...membership.user,
+      status: membership.user.status ?? "active",
+    },
+  }));
+}
+
+export async function getAllBatchUsers() {
+  const user = await getCurrentUser();
+  if (!user || !isAdmin(user)) return [];
+
+  const batchUsers = await prisma.userBatch.findMany({
+    include: { user: true, batch: true },
+    orderBy: [{ batchId: "asc" }, { invitedAt: "desc" }],
+  });
 
   return batchUsers.map((membership) => ({
     ...membership,

--- a/founder-sprint/src/app/(dashboard)/admin/AdminView.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/AdminView.tsx
@@ -33,6 +33,7 @@ interface Company {
   tags: string[];
   memberCount: number;
   memberAvatars: Array<string | null>;
+  batchNames: string[];
 }
 
 interface AdminViewProps {

--- a/founder-sprint/src/app/(dashboard)/admin/companies/CompanyList.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/companies/CompanyList.tsx
@@ -22,6 +22,7 @@ interface Company {
   tags: string[];
   memberCount: number;
   memberAvatars: Array<string | null>;
+  batchNames: string[];
 }
 
 interface CompanyListProps {
@@ -33,6 +34,33 @@ export function CompanyList({ initialCompanies }: CompanyListProps) {
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; name: string } | null>(null);
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
+
+  const renderBatchNames = (batchNames: string[]) => {
+    if (batchNames.length === 0) {
+      return <span style={{ color: "#999" }}>-</span>;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {batchNames.map((batchName) => (
+          <span
+            key={batchName}
+            className="text-xs"
+            style={{
+              padding: "3px 8px",
+              borderRadius: "999px",
+              backgroundColor: "#f3f4f6",
+              color: "#4b5563",
+              border: "1px solid #e5e7eb",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {batchName}
+          </span>
+        ))}
+      </div>
+    );
+  };
 
   const handleDelete = async (id: string) => {
     startTransition(async () => {
@@ -103,6 +131,9 @@ export function CompanyList({ initialCompanies }: CompanyListProps) {
                       {company.hqLocation}
                     </p>
                   )}
+                  <div className="mt-2">
+                    {renderBatchNames(company.batchNames)}
+                  </div>
                 </div>
               </div>
 
@@ -135,6 +166,9 @@ export function CompanyList({ initialCompanies }: CompanyListProps) {
               <tr style={{ borderBottom: "1px solid #e0e0e0" }}>
                 <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "#666" }}>
                   Company
+                </th>
+                <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "#666" }}>
+                  Batches
                 </th>
                 <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "#666" }}>
                   Industry
@@ -177,6 +211,9 @@ export function CompanyList({ initialCompanies }: CompanyListProps) {
                         )}
                       </div>
                     </Link>
+                  </td>
+                  <td className="py-3 px-4">
+                    {renderBatchNames(company.batchNames)}
                   </td>
                   <td className="py-3 px-4">
                     <span style={{ color: "#2F2C26" }}>

--- a/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useTransition, useEffect, useRef } from "react";
-import { useSearchParams } from "next/navigation";
+import { useState, useTransition, useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
+  getAllBatchUsers,
   getBatchUsers,
   inviteUser,
   bulkInviteUsers,
@@ -111,17 +113,21 @@ const baseRoleOptions = [
 ];
 
 export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementProps) {
-  const [selectedBatchId, setSelectedBatchId] = useState<string>("");
   const [users, setUsers] = useState<BatchUser[]>([]);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const toast = useToast();
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const selectedBatchId = searchParams.get("batchId") || "";
+  const sourceInviteBatchId = searchParams.get("sourceBatchId") || "";
+  const shouldOpenInviteFromQuery = searchParams.get("openInvite") === "1";
   const [isLoadingUsers, setIsLoadingUsers] = useState(false);
   const [formError, setFormError] = useState("");
   const [inviteLink, setInviteLink] = useState<string | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
-  const [confirmRemove, setConfirmRemove] = useState<{ userId: string; userName: string } | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<{ userId: string; userName: string; batchId: string; batchName: string } | null>(null);
   const [companies, setCompanies] = useState<Array<{ id: string; name: string; _count: { members: number } }>>([]);
   const [selectedRole, setSelectedRole] = useState("founder");
   const [inviteMode, setInviteMode] = useState<"single" | "bulk">("single");
@@ -131,11 +137,11 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
   const [isLoadingAudit, setIsLoadingAudit] = useState(false);
   const [activityEntries, setActivityEntries] = useState<FounderActivityEntry[]>([]);
   const [isLoadingActivity, setIsLoadingActivity] = useState(false);
-  const [sourceInviteBatchId, setSourceInviteBatchId] = useState<string>("");
   const [sourceInviteCandidates, setSourceInviteCandidates] = useState<SourceBatchInviteCandidate[]>([]);
   const [selectedSourceUserIds, setSelectedSourceUserIds] = useState<string[]>([]);
   const [isLoadingSourceCandidates, setIsLoadingSourceCandidates] = useState(false);
   const linkCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadedScopeRef = useRef<string | null>(null);
   const roleOptions = canAssignSuperAdmin
     ? [{ value: "super_admin", label: "Super Admin" }, ...baseRoleOptions]
     : baseRoleOptions;
@@ -146,41 +152,60 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     };
   }, []);
 
-  // Handle batch selection change
-  const handleBatchChange = (batchId: string) => {
-    setSelectedBatchId(batchId);
-    setUsers([]); // Clear users when changing batch
-    setAuditEntries([]);
-    if (batchId) {
-      loadUsers(batchId);
-      loadAuditLogs(batchId);
-      loadFounderActivity(batchId);
-    }
-  };
-
   // Load users function
-  const loadUsers = (batchId: string) => {
+  const loadUsers = useCallback((batchId: string) => {
     setIsLoadingUsers(true);
-    getBatchUsers(batchId)
+    const usersRequest = batchId ? getBatchUsers(batchId) : getAllBatchUsers();
+    usersRequest
       .then((data) => setUsers(data as BatchUser[]))
       .catch(() => setUsers([]))
       .finally(() => setIsLoadingUsers(false));
-  };
+  }, []);
 
-  const loadAuditLogs = (batchId: string) => {
+  const loadAuditLogs = useCallback((batchId: string) => {
     setIsLoadingAudit(true);
     getRecentUserManagementAuditLogs(batchId)
       .then((data) => setAuditEntries(data as AuditEntry[]))
       .catch(() => setAuditEntries([]))
       .finally(() => setIsLoadingAudit(false));
-  };
+  }, []);
 
-  const loadFounderActivity = (batchId: string) => {
+  const loadFounderActivity = useCallback((batchId: string) => {
     setIsLoadingActivity(true);
     getFounderActivitySummaries(batchId)
       .then((data) => setActivityEntries(data as FounderActivityEntry[]))
       .catch(() => setActivityEntries([]))
       .finally(() => setIsLoadingActivity(false));
+  }, []);
+
+  const loadScope = useCallback((batchId: string) => {
+    setUsers([]);
+    setAuditEntries([]);
+    setActivityEntries([]);
+    loadUsers(batchId);
+    if (batchId) {
+      loadAuditLogs(batchId);
+      loadFounderActivity(batchId);
+    }
+  }, [loadUsers, loadAuditLogs, loadFounderActivity]);
+
+  // Handle batch selection change
+  const handleBatchChange = (batchId: string) => {
+    setSourceInviteCandidates([]);
+    setSelectedSourceUserIds([]);
+
+    const params = new URLSearchParams(searchParams.toString());
+    if (batchId) {
+      params.set("batchId", batchId);
+    } else {
+      params.delete("batchId");
+      params.delete("sourceBatchId");
+      params.delete("openInvite");
+      setIsInviteModalOpen(false);
+    }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
   };
 
   // Fetch companies (not batch-scoped)
@@ -190,33 +215,39 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     });
   }, []);
   useEffect(() => {
-    const batchIdFromQuery = searchParams.get("batchId") || "";
-    const sourceBatchIdFromQuery = searchParams.get("sourceBatchId") || "";
-    const shouldOpenInvite = searchParams.get("openInvite") === "1";
-
-    if (batchIdFromQuery && batchIdFromQuery !== selectedBatchId) {
-      handleBatchChange(batchIdFromQuery);
+    if (loadedScopeRef.current !== selectedBatchId) {
+      loadedScopeRef.current = selectedBatchId;
+      loadScope(selectedBatchId);
     }
 
-    if (sourceBatchIdFromQuery !== sourceInviteBatchId) {
-      setSourceInviteBatchId(sourceBatchIdFromQuery);
+    if (shouldOpenInviteFromQuery && selectedBatchId) {
+      Promise.resolve().then(() => setIsInviteModalOpen(true));
     }
-
-    if (shouldOpenInvite) {
-      setIsInviteModalOpen(true);
-    }
-  }, [searchParams]);
+  }, [selectedBatchId, shouldOpenInviteFromQuery, loadScope]);
 
   useEffect(() => {
+    let cancelled = false;
+
     if (!sourceInviteBatchId || !selectedBatchId) {
-      setSourceInviteCandidates([]);
-      setSelectedSourceUserIds([]);
-      return;
+      Promise.resolve().then(() => {
+        if (cancelled) return;
+        setSourceInviteCandidates([]);
+        setSelectedSourceUserIds([]);
+        setIsLoadingSourceCandidates(false);
+      });
+      return () => {
+        cancelled = true;
+      };
     }
 
-    setIsLoadingSourceCandidates(true);
-    getBatchUsers(sourceInviteBatchId)
-      .then((data) => {
+    Promise.resolve().then(async () => {
+      if (cancelled) return;
+      setIsLoadingSourceCandidates(true);
+
+      try {
+        const data = await getBatchUsers(sourceInviteBatchId);
+        if (cancelled) return;
+
         const candidates = (data as BatchUser[])
           .filter((membership) => membership.status === "active")
           .map((membership) => ({
@@ -230,12 +261,18 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
           }));
         setSourceInviteCandidates(candidates);
         setSelectedSourceUserIds([]);
-      })
-      .catch(() => {
+      } catch {
+        if (cancelled) return;
         setSourceInviteCandidates([]);
         setSelectedSourceUserIds([]);
-      })
-      .finally(() => setIsLoadingSourceCandidates(false));
+      } finally {
+        if (!cancelled) setIsLoadingSourceCandidates(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [sourceInviteBatchId, selectedBatchId]);
 
   const handleInviteSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -324,12 +361,22 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     });
   };
 
-  const handleRoleChange = async (userId: string, newRole: string) => {
+  const refreshCurrentScope = () => loadUsers(selectedBatchId);
+  const refreshBatchPanelsIfVisible = (batchId: string) => {
+    if (selectedBatchId !== batchId) return;
+    loadAuditLogs(batchId);
+    loadFounderActivity(batchId);
+  };
+
+  const handleRoleChange = async (userBatch: BatchUser, newRole: string) => {
     startTransition(async () => {
-      const result = await updateUserRole(userId, selectedBatchId, newRole as UserRole);
+      const result = await updateUserRole(userBatch.userId, userBatch.batchId, newRole as UserRole);
 
       if (result.success) {
-        loadUsers(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(userBatch.batchId);
+      } else {
+        toast.error(result.error);
       }
     });
   };
@@ -340,10 +387,10 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       : (userBatch.additionalRoles || []).filter((additionalRole) => additionalRole !== role);
 
     startTransition(async () => {
-      const result = await updateAdditionalRoles(userBatch.userId, selectedBatchId, nextRoles);
+      const result = await updateAdditionalRoles(userBatch.userId, userBatch.batchId, nextRoles);
       if (result.success) {
-        loadUsers(selectedBatchId);
-        loadAuditLogs(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(userBatch.batchId);
       } else {
         toast.error(result.error);
       }
@@ -404,7 +451,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       <div className={`flex ${compact ? "flex-col" : "flex-col items-end"} gap-2`}>
         <select
           value={userBatch.role}
-          onChange={(e) => handleRoleChange(userBatch.userId, e.target.value)}
+          onChange={(e) => handleRoleChange(userBatch, e.target.value)}
           disabled={isPending}
           className={compact ? "form-input flex-1" : "form-input"}
           style={compact ? { fontSize: "14px", height: 36 } : { minWidth: 140, fontSize: "14px", height: 36 }}
@@ -418,34 +465,38 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     );
   };
 
-  const handleRemoveUser = async (userId: string) => {
+  const handleRemoveUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await removeUserFromBatch(userId, selectedBatchId);
+      const result = await removeUserFromBatch(userId, batchId);
 
       if (result.success) {
-        loadUsers(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
         setConfirmRemove(null);
-      }
-    });
-  };
-
-  const handleCancelInvite = async (userId: string, userName: string) => {
-    if (!confirm(`Cancel invite for ${userName}? They will need to be re-invited.`)) return;
-
-    startTransition(async () => {
-      const result = await cancelInvite(userId);
-
-      if (result.success) {
-        loadUsers(selectedBatchId);
       } else {
         toast.error(result.error);
       }
     });
   };
 
-  const handleResendInvite = async (userId: string) => {
+  const handleCancelInvite = async (userId: string, batchId: string, userName: string, batchName: string) => {
+    if (!confirm(`Cancel invite for ${userName} in ${batchName}? They will need to be re-invited.`)) return;
+
     startTransition(async () => {
-      const result = await resendInvite(userId, selectedBatchId);
+      const result = await cancelInvite(userId, batchId);
+
+      if (result.success) {
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  const handleResendInvite = async (userId: string, batchId: string) => {
+    startTransition(async () => {
+      const result = await resendInvite(userId, batchId);
       if (result.success) {
         if (result.warning) {
           toast.warning(result.warning);
@@ -453,63 +504,63 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
         } else {
           toast.success("Invitation resent");
         }
-        loadAuditLogs(selectedBatchId);
+        refreshBatchPanelsIfVisible(batchId);
       } else {
         toast.error(result.error);
       }
     });
   };
 
-  const handleDeactivateUser = async (userId: string, userName: string) => {
+  const handleDeactivateUser = async (userId: string, batchId: string, userName: string) => {
     if (!confirm(`Deactivate ${userName}? They will no longer be able to sign in.`)) return;
 
     startTransition(async () => {
-      const result = await deactivateUser(userId, selectedBatchId);
+      const result = await deactivateUser(userId, batchId);
       if (result.success) {
         toast.success("User deactivated");
-        loadUsers(selectedBatchId);
-        loadAuditLogs(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
       } else {
         toast.error(result.error);
       }
     });
   };
 
-  const handleReactivateUser = async (userId: string) => {
+  const handleReactivateUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await reactivateUser(userId, selectedBatchId);
+      const result = await reactivateUser(userId, batchId);
       if (result.success) {
         toast.success("User reactivated");
-        loadUsers(selectedBatchId);
-        loadAuditLogs(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
       } else {
         toast.error(result.error);
       }
     });
   };
 
-  const handleDropoutUser = async (userId: string, userName: string) => {
-    if (!confirm(`Mark ${userName} as dropped out from this batch? They will lose access to this batch but remain active in other batches.`)) return;
+  const handleDropoutUser = async (userId: string, batchId: string, userName: string, batchName: string) => {
+    if (!confirm(`Mark ${userName} as dropped out from ${batchName}? They will lose access to this batch but remain active in other batches.`)) return;
 
     startTransition(async () => {
-      const result = await dropoutUserFromBatch(userId, selectedBatchId);
+      const result = await dropoutUserFromBatch(userId, batchId);
       if (result.success) {
         toast.success("User dropped out from batch");
-        loadUsers(selectedBatchId);
-        loadAuditLogs(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
       } else {
         toast.error(result.error);
       }
     });
   };
 
-  const handleRestoreBatchUser = async (userId: string) => {
+  const handleRestoreBatchUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await restoreUserBatch(userId, selectedBatchId);
+      const result = await restoreUserBatch(userId, batchId);
       if (result.success) {
         toast.success("Batch membership restored");
-        loadUsers(selectedBatchId);
-        loadAuditLogs(selectedBatchId);
+        refreshCurrentScope();
+        refreshBatchPanelsIfVisible(batchId);
       } else {
         toast.error(result.error);
       }
@@ -559,14 +610,34 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     return `${entry.userName} performed ${entry.action}`;
   };
 
-  const batchOptions = batches.map((batch) => ({
-    value: batch.id,
-    label: `${batch.name} (${getBatchStatusLabel({ status: batch.status as BatchStatus, endDate: new Date(batch.endDate) })})`,
-  }));
+  const batchOptions = [
+    { value: "", label: "All Users" },
+    ...batches.map((batch) => ({
+      value: batch.id,
+      label: `${batch.name} (${getBatchStatusLabel({ status: batch.status as BatchStatus, endDate: new Date(batch.endDate) })})`,
+    })),
+  ];
 
   const selectedBatch = batches.find((b) => b.id === selectedBatchId);
   const sourceInviteBatch = batches.find((b) => b.id === sourceInviteBatchId);
   const founderChoices = users.filter((userBatch) => getVisibleRoles(userBatch).includes("founder"));
+  const isAllUsersView = !selectedBatchId;
+  const userListDescription = isAllUsersView
+    ? `Showing all batch memberships (${users.length})`
+    : `Showing users in ${selectedBatch?.name || "selected batch"} (${users.length})`;
+
+  const renderBatchBadge = (userBatch: BatchUser) => (
+    <Badge variant="outline" size="sm">{userBatch.batch.name}</Badge>
+  );
+
+  const openRemoveConfirm = (userBatch: BatchUser) => {
+    setConfirmRemove({
+      userId: userBatch.userId,
+      userName: getDisplayName(userBatch.user),
+      batchId: userBatch.batchId,
+      batchName: userBatch.batch.name,
+    });
+  };
 
   return (
     <div className="space-y-6">
@@ -575,9 +646,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
         <div className="flex items-center gap-4">
           <div className="flex-1">
             <Select
-              label="Select Batch"
+              label="Filter by Batch"
               options={batchOptions}
-              placeholder="Choose a batch to view users..."
+              placeholder="Choose a batch filter..."
               value={selectedBatchId}
               onChange={(e) => handleBatchChange(e.target.value)}
             />
@@ -593,12 +664,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       </div>
 
       {/* Users list */}
-      {!selectedBatchId ? (
-        <EmptyState
-          title="No batch selected"
-          description="Select a batch from the dropdown above to view and manage its users"
-        />
-      ) : isLoadingUsers ? (
+      {isLoadingUsers ? (
         <div className="card text-center py-12">
           <p className="text-lg" style={{ color: "var(--color-foreground-secondary)" }}>
             Loading users...
@@ -606,10 +672,10 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
         </div>
       ) : users.length === 0 ? (
         <EmptyState
-          title="No users in this batch"
-          description="Invite users to get started"
+          title={isAllUsersView ? "No users found" : "No users in this batch"}
+          description={isAllUsersView ? "No batch memberships found yet" : "Invite users to get started"}
           action={
-            selectedBatch ? (
+            selectedBatchId && selectedBatch ? (
               <Button onClick={() => setIsInviteModalOpen(true)}>
                 Invite First User
               </Button>
@@ -618,6 +684,11 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
         />
         ) : (
           <div className="space-y-4">
+            <div className="card py-3">
+              <p className="text-sm" style={{ color: "var(--color-foreground-secondary)" }}>
+                {userListDescription}
+              </p>
+            </div>
             <div className="md:hidden space-y-4">
               {users.map((userBatch) => (
                 <div
@@ -628,8 +699,11 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     boxShadow: "0 1px 2px rgba(0,0,0,0.05)"
                   }}
                 >
-                  <div className="flex items-center gap-3">
-                     <Avatar
+                  <Link
+                    href={`/profile/${userBatch.user.id}`}
+                    className="flex items-center gap-3 hover:opacity-80"
+                  >
+                    <Avatar
                       src={userBatch.user.profileImage}
                       name={getDisplayName(userBatch.user)}
                       size={40}
@@ -640,6 +714,10 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         {userBatch.user.email}
                       </div>
                     </div>
+                  </Link>
+                  <div className="flex items-center gap-2 text-sm" style={{ color: "var(--color-foreground-secondary)" }}>
+                    <span>Batch</span>
+                    {renderBatchBadge(userBatch)}
                   </div>
                   
                   <div className="flex items-center justify-between gap-2">
@@ -667,7 +745,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleResendInvite(userBatch.userId)}
+                          onClick={() => handleResendInvite(userBatch.userId, userBatch.batchId)}
                           disabled={isPending}
                         >
                           Resend Invite
@@ -675,7 +753,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleCancelInvite(userBatch.userId, getDisplayName(userBatch.user))}
+                          onClick={() => handleCancelInvite(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
                           disabled={isPending}
                         >
                           Cancel Invite
@@ -686,7 +764,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                           <Button
                             variant="ghost"
                             size="sm"
-                        onClick={() => handleReactivateUser(userBatch.userId)}
+                        onClick={() => handleReactivateUser(userBatch.userId, userBatch.batchId)}
                         disabled={isPending}
                       >
                             Reactivate
@@ -695,7 +773,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleRestoreBatchUser(userBatch.userId)}
+                            onClick={() => handleRestoreBatchUser(userBatch.userId, userBatch.batchId)}
                             disabled={isPending}
                           >
                             Restore Batch
@@ -705,7 +783,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleDropoutUser(userBatch.userId, getDisplayName(userBatch.user))}
+                              onClick={() => handleDropoutUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
                               disabled={isPending || userBatch.status !== "active"}
                             >
                               Dropout
@@ -713,7 +791,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                             <Button
                               variant="danger"
                               size="sm"
-                              onClick={() => handleDeactivateUser(userBatch.userId, getDisplayName(userBatch.user))}
+                              onClick={() => handleDeactivateUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user))}
                               disabled={isPending}
                             >
                               Deactivate
@@ -723,7 +801,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     <Button
                       variant="danger"
                       size="sm"
-                      onClick={() => setConfirmRemove({ userId: userBatch.userId, userName: getDisplayName(userBatch.user) })}
+                      onClick={() => openRemoveConfirm(userBatch)}
                       disabled={isPending}
                     >
                       Remove
@@ -747,6 +825,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     Email
                   </th>
                   <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "var(--color-foreground-secondary)" }}>
+                    Batch
+                  </th>
+                  <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "var(--color-foreground-secondary)" }}>
                     Role
                   </th>
                   <th className="text-left py-3 px-4 text-sm font-medium" style={{ color: "var(--color-foreground-secondary)" }}>
@@ -767,19 +848,29 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     style={{ borderBottom: "1px solid var(--color-card-border)" }}
                   >
                     <td className="py-3 px-4">
-                      <div className="flex items-center gap-3">
+                      <Link
+                        href={`/profile/${userBatch.user.id}`}
+                        className="flex items-center gap-3 hover:opacity-80"
+                      >
                          <Avatar
                           src={userBatch.user.profileImage}
                           name={getDisplayName(userBatch.user)}
                           size={36}
                         />
                         <span className="font-medium">{getDisplayName(userBatch.user)}</span>
-                      </div>
+                      </Link>
                     </td>
                     <td className="py-3 px-4">
-                      <span style={{ color: "var(--color-foreground-secondary)" }}>
+                      <Link
+                        href={`/profile/${userBatch.user.id}`}
+                        className="hover:opacity-80"
+                        style={{ color: "var(--color-foreground-secondary)" }}
+                      >
                         {userBatch.user.email}
-                      </span>
+                      </Link>
+                    </td>
+                    <td className="py-3 px-4">
+                      {renderBatchBadge(userBatch)}
                     </td>
                     <td className="py-3 px-4">
                       {renderRoleBadges(userBatch)}
@@ -809,7 +900,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleResendInvite(userBatch.userId)}
+                              onClick={() => handleResendInvite(userBatch.userId, userBatch.batchId)}
                               disabled={isPending}
                             >
                               Resend Invite
@@ -817,7 +908,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleCancelInvite(userBatch.userId, getDisplayName(userBatch.user))}
+                              onClick={() => handleCancelInvite(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
                               disabled={isPending}
                             >
                               Cancel Invite
@@ -828,7 +919,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                       <Button
                         variant="ghost"
                         size="sm"
-                            onClick={() => handleReactivateUser(userBatch.userId)}
+                            onClick={() => handleReactivateUser(userBatch.userId, userBatch.batchId)}
                             disabled={isPending}
                           >
                         Reactivate
@@ -837,7 +928,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleRestoreBatchUser(userBatch.userId)}
+                        onClick={() => handleRestoreBatchUser(userBatch.userId, userBatch.batchId)}
                         disabled={isPending}
                       >
                         Restore Batch
@@ -847,7 +938,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleDropoutUser(userBatch.userId, getDisplayName(userBatch.user))}
+                          onClick={() => handleDropoutUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
                           disabled={isPending || userBatch.status !== "active"}
                         >
                           Dropout
@@ -855,7 +946,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         <Button
                           variant="danger"
                           size="sm"
-                          onClick={() => handleDeactivateUser(userBatch.userId, getDisplayName(userBatch.user))}
+                          onClick={() => handleDeactivateUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user))}
                           disabled={isPending}
                         >
                           Deactivate
@@ -865,7 +956,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                         <Button
                           variant="danger"
                           size="sm"
-                          onClick={() => setConfirmRemove({ userId: userBatch.userId, userName: getDisplayName(userBatch.user) })}
+                          onClick={() => openRemoveConfirm(userBatch)}
                           disabled={isPending}
                         >
                           Remove
@@ -1380,7 +1471,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       >
         <div className="space-y-4">
           <p style={{ color: "var(--color-foreground-secondary)" }}>
-            Are you sure you want to remove <strong>{confirmRemove?.userName}</strong> from this batch?
+            Are you sure you want to remove <strong>{confirmRemove?.userName}</strong> from <strong>{confirmRemove?.batchName}</strong>?
             This action cannot be undone.
           </p>
 
@@ -1394,7 +1485,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
             </Button>
             <Button
               variant="danger"
-              onClick={() => confirmRemove && handleRemoveUser(confirmRemove.userId)}
+              onClick={() => confirmRemove && handleRemoveUser(confirmRemove.userId, confirmRemove.batchId)}
               loading={isPending}
             >
               Remove User

--- a/founder-sprint/src/app/(dashboard)/feed/FeedView.tsx
+++ b/founder-sprint/src/app/(dashboard)/feed/FeedView.tsx
@@ -80,6 +80,8 @@ export function FeedView({ posts, archivedPosts = [], currentUser, isAdmin = fal
 
   const [likedIds, setLikedIds] = useState<Set<string>>(new Set(likedPostIds));
   const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set(bookmarkedPostIds));
+  const [shareCopiedPostId, setShareCopiedPostId] = useState<string | null>(null);
+  const shareCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const serverLikedIds = useMemo(() => new Set(likedPostIds), [likedPostIds]);
 
   useEffect(() => {
@@ -89,6 +91,12 @@ export function FeedView({ posts, archivedPosts = [], currentUser, isAdmin = fal
   useEffect(() => {
     setBookmarkedIds(new Set(bookmarkedPostIds));
   }, [bookmarkedPostIds]);
+
+  useEffect(() => {
+    return () => {
+      if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current);
+    };
+  }, []);
 
   const handleTabChange = (tabId: string) => {
     setActiveTab(tabId);
@@ -196,6 +204,11 @@ export function FeedView({ posts, archivedPosts = [], currentUser, isAdmin = fal
       }
 
       toast.success("Link copied to clipboard");
+      setShareCopiedPostId(postId);
+      if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current);
+      shareCopiedTimerRef.current = setTimeout(() => {
+        setShareCopiedPostId((currentPostId) => currentPostId === postId ? null : currentPostId);
+      }, 2000);
     } catch {
       toast.error("Failed to copy link");
     }
@@ -412,6 +425,7 @@ export function FeedView({ posts, archivedPosts = [], currentUser, isAdmin = fal
                 views={post.viewCount}
                 isLiked={likedIds.has(post.id)}
                 isBookmarked={bookmarkedIds.has(post.id)}
+                isShareCopied={shareCopiedPostId === post.id}
                 onLike={() => handleToggleLike(post.id)}
                 onComment={() => router.push(`/feed/${post.id}`)}
                 onBookmark={() => handleBookmark(post.id)}

--- a/founder-sprint/src/components/bookface/PostCard.tsx
+++ b/founder-sprint/src/components/bookface/PostCard.tsx
@@ -35,6 +35,7 @@ export interface PostCardProps {
   views?: number;
   isLiked?: boolean;
   isBookmarked?: boolean;
+  isShareCopied?: boolean;
   onLike?: () => void;
   onComment?: () => void;
   onBookmark?: () => void;
@@ -352,6 +353,7 @@ export const PostCard: React.FC<PostCardProps> = ({
   views,
   isLiked = false,
   isBookmarked = false,
+  isShareCopied = false,
   onLike,
   onComment,
   onBookmark,
@@ -463,9 +465,18 @@ export const PostCard: React.FC<PostCardProps> = ({
           {comments > 0 && comments}
         </button>
 
-        <button type="button" style={styles.actionBtn} onClick={onShare}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" /><polyline points="16 6 12 2 8 6" /><line x1="12" y1="2" x2="12" y2="15" /></svg>
-          Share
+        <button
+          type="button"
+          style={{ ...styles.actionBtn, ...(isShareCopied ? styles.actionBtnActive : {}) }}
+          onClick={onShare}
+          aria-live="polite"
+        >
+          {isShareCopied ? (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><polyline points="20 6 9 17 4 12" /></svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" /><polyline points="16 6 12 2 8 6" /><line x1="12" y1="2" x2="12" y2="15" /></svg>
+          )}
+          {isShareCopied ? 'Copied' : 'Share'}
         </button>
 
         <button


### PR DESCRIPTION
## Overview

This PR updates the admin directory flows and feed sharing feedback.

### Admin Companies
- Shows associated batch names for each company in the Companies table.
- Adds the same batch visibility to mobile company cards.

### Admin Users
- Treats no `batchId` as an "All Users" membership view instead of rendering "No batch selected".
- Adds an `All Users` filter option and keeps specific batch selection as a filter.
- Adds a Batch column/chip so duplicate user accounts across batches remain understandable.
- Links user identity areas to `/profile/{userId}` without making the whole row clickable.
- Makes row actions use the row's `userBatch.batchId`, not the current filter value.
- Changes invite cancellation to be batch-specific with `cancelInvite(userId, batchId)`.

### Feed Share Feedback
- Keeps the existing share button design, but switches the button to a check icon and `Copied` label for 2 seconds after successful copy.

## Why

The admin Users tab should be useful immediately, and the Companies tab should expose batch membership context. In all-users mode, user-management rows are still batch-membership rows, so mutation actions must be scoped to the row's actual batch to avoid accidental cross-batch changes.

## Validation

- `npx eslint 'src/app/(dashboard)/feed/FeedView.tsx' 'src/components/bookface/PostCard.tsx' 'src/actions/user-management.ts' 'src/app/(dashboard)/admin/users/UserManagement.tsx' 'src/app/(dashboard)/admin/AdminView.tsx' 'src/app/(dashboard)/admin/companies/CompanyList.tsx'`
  - Passed with existing `<img>` warnings only.
- `npx tsc --noEmit`
- `git diff --check`

## Notes

Image layout/cropping improvements for feed attachments are intentionally not included here; that needs a separate UI plan and implementation pass.
