### PR TITLE
[codex] Clean up notification cards and add mark all read

### DIFF
--- a/founder-sprint/src/actions/notification.ts
+++ b/founder-sprint/src/actions/notification.ts
@@ -138,3 +138,21 @@ export async function markNotificationRead(
 
   return { success: true, data: { id: notification.id } };
 }
+
+export async function markAllNotificationsRead(): Promise<ActionResult<{ count: number }>> {
+  const user = await getCurrentUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const result = await prisma.notification.updateMany({
+    where: {
+      userId: user.id,
+      read: false,
+    },
+    data: { read: true },
+  });
+
+  revalidatePath("/notifications");
+  revalidateTag("notifications");
+
+  return { success: true, data: { count: result.count } };
+}

--- a/founder-sprint/src/app/(dashboard)/notifications/NotificationsListClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/notifications/NotificationsListClient.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
-import { markNotificationRead } from "@/actions/notification";
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { markAllNotificationsRead, markNotificationRead } from "@/actions/notification";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 
@@ -25,10 +24,42 @@ export function NotificationsListClient({
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [items, setItems] = useState(notifications);
+  const unreadCount = useMemo(
+    () => items.filter((notification) => !notification.read).length,
+    [items]
+  );
+
+  useEffect(() => {
+    setItems(notifications);
+  }, [notifications]);
+
+  const markLocalNotificationRead = (notificationId: string) => {
+    setItems((current) =>
+      current.map((notification) =>
+        notification.id === notificationId
+          ? { ...notification, read: true }
+          : notification
+      )
+    );
+  };
+
+  const handleMarkAllRead = () => {
+    startTransition(async () => {
+      const result = await markAllNotificationsRead();
+      if (result.success) {
+        setItems((current) =>
+          current.map((notification) => ({ ...notification, read: true }))
+        );
+        router.refresh();
+      }
+    });
+  };
 
   const handleOpenNotification = (notification: NotificationItem) => {
     startTransition(async () => {
       await markNotificationRead(notification.id);
+      markLocalNotificationRead(notification.id);
       if (notification.targetPath) {
         router.push(notification.targetPath);
       }
@@ -46,7 +77,20 @@ export function NotificationsListClient({
 
   return (
     <div className="space-y-3">
-      {notifications.map((notification) => (
+      {unreadCount > 0 && (
+        <div className="flex items-center justify-end">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleMarkAllRead}
+            loading={isPending}
+          >
+            Mark all as read
+          </Button>
+        </div>
+      )}
+
+      {items.map((notification) => (
         <div
           key={notification.id}
           className="card"
@@ -102,6 +146,7 @@ export function NotificationsListClient({
                   onClick={() => {
                     startTransition(async () => {
                       await markNotificationRead(notification.id);
+                      markLocalNotificationRead(notification.id);
                       router.refresh();
                     });
                   }}
@@ -111,11 +156,6 @@ export function NotificationsListClient({
                 </Button>
               )}
             </div>
-            {notification.targetPath && (
-              <Link href={notification.targetPath} className="text-sm" style={{ color: "var(--color-primary)" }}>
-                {notification.targetPath}
-              </Link>
-            )}
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Overview

Cleans up the notifications list UI and adds a bulk read action.

## Changes

- Hides raw internal target paths like `/settings`, `/feed/...`, and `/assignments/...` from notification cards.
- Keeps the existing `Open` button behavior for navigating to notification targets.
- Adds `Mark all as read` when unread notifications exist.
- Updates local UI state immediately after individual or bulk read actions.

## Why

The raw target paths made the notifications list visually noisy and exposed implementation details that users do not need. Users also needed a fast way to clear unread notification badges without opening each item one by one.

## Validation

- `npx eslint 'src/actions/notification.ts' 'src/app/(dashboard)/notifications/NotificationsListClient.tsx' 'src/app/(dashboard)/notifications/page.tsx'`
- `npx tsc --noEmit`
- `git diff --check`
