### PR TITLE
[codex] Add image messages and direct founder compose

### DIFF
--- a/founder-sprint/prisma/migrations/20260427134000_add_message_attachments/migration.sql
+++ b/founder-sprint/prisma/migrations/20260427134000_add_message_attachments/migration.sql
@@ -1,0 +1,22 @@
+-- Store image attachments for direct and group messages.
+CREATE TABLE "message_attachments" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "message_id" UUID NOT NULL,
+  "image_url" TEXT NOT NULL,
+  "storage_path" TEXT NOT NULL,
+  "file_name" TEXT,
+  "mime_type" TEXT,
+  "size_bytes" INTEGER,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "message_attachments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "message_attachments_message_id_idx"
+  ON "message_attachments"("message_id");
+
+ALTER TABLE "message_attachments"
+  ADD CONSTRAINT "message_attachments_message_id_fkey"
+  FOREIGN KEY ("message_id") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "message_attachments" ENABLE ROW LEVEL SECURITY;

--- a/founder-sprint/prisma/schema.prisma
+++ b/founder-sprint/prisma/schema.prisma
@@ -889,12 +889,29 @@ model Message {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 
-  conversation Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
-  sender       User?        @relation(fields: [senderId], references: [id], onDelete: SetNull)
+  conversation Conversation        @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  sender       User?               @relation(fields: [senderId], references: [id], onDelete: SetNull)
+  attachments  MessageAttachment[]
 
   @@index([conversationId, createdAt])
   @@index([senderId])
   @@map("messages")
+}
+
+model MessageAttachment {
+  id          String   @id @default(uuid()) @db.Uuid
+  messageId   String   @map("message_id") @db.Uuid
+  imageUrl    String   @map("image_url")
+  storagePath String   @map("storage_path")
+  fileName    String?  @map("file_name")
+  mimeType    String?  @map("mime_type")
+  sizeBytes   Int?     @map("size_bytes")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@index([messageId])
+  @@map("message_attachments")
 }
 
 // SessionBatch - Junction table for Session <-> Batch (many-to-many)

--- a/founder-sprint/src/actions/messaging.ts
+++ b/founder-sprint/src/actions/messaging.ts
@@ -2,8 +2,10 @@
 
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/permissions";
-import { requireActiveBatch } from "@/lib/batch-gate";
 import { revalidatePath } from "next/cache";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import { MESSAGE_IMAGE_BUCKET, MESSAGE_IMAGE_MAX_FILES } from "@/lib/message-images";
 import type { ActionResult } from "@/types";
 
 export interface ConversationListItem {
@@ -23,6 +25,24 @@ export interface MessageItem {
   content: string;
   createdAt: Date;
   sender: { id: string; name: string | null; profileImage: string | null } | null;
+  attachments: MessageAttachmentItem[];
+}
+
+export interface MessageAttachmentItem {
+  id: string;
+  imageUrl: string;
+  storagePath: string;
+  fileName: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+}
+
+export interface MessageAttachmentInput {
+  imageUrl: string;
+  storagePath: string;
+  fileName?: string | null;
+  mimeType?: string | null;
+  sizeBytes?: number | null;
 }
 
 export interface ConversationDetail {
@@ -73,6 +93,49 @@ type ParticipantConversation = {
     }[];
   };
 };
+
+const MessageAttachmentInputSchema = z.object({
+  imageUrl: z.string().url(),
+  storagePath: z.string().min(1).max(500),
+  fileName: z.string().max(255).nullable().optional(),
+  mimeType: z.string().max(100).nullable().optional(),
+  sizeBytes: z.number().int().min(0).max(5 * 1024 * 1024).nullable().optional(),
+});
+
+const MessageAttachmentsInputSchema = z
+  .array(MessageAttachmentInputSchema)
+  .max(MESSAGE_IMAGE_MAX_FILES);
+
+const MessageImagePathsSchema = z
+  .array(z.string().min(1).max(500))
+  .max(MESSAGE_IMAGE_MAX_FILES);
+
+function createStorageClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey);
+}
+
+async function deleteMessageImageStoragePaths(paths: string[]) {
+  const uniquePaths = [...new Set(paths.map((path) => path.trim()).filter(Boolean))];
+  if (uniquePaths.length === 0) return;
+
+  const storage = createStorageClient();
+  if (!storage) {
+    console.error("[Messaging] Storage cleanup skipped: service role client not configured.");
+    return;
+  }
+
+  const { error } = await storage.storage.from(MESSAGE_IMAGE_BUCKET).remove(uniquePaths);
+  if (error) {
+    console.error("[Messaging] Failed to clean up message images from storage:", error);
+  }
+}
 
 async function getUnreadCountsByConversation(
   userId: string,
@@ -262,6 +325,26 @@ export async function getOrCreateDMConversation(
   } catch {
     return { success: false, error: "Failed to create conversation" };
   }
+}
+
+export async function cleanupUploadedMessageImages(
+  paths: string[]
+): Promise<ActionResult<{ removed: number }>> {
+  const user = await getCurrentUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const parsed = MessageImagePathsSchema.safeParse(paths);
+  if (!parsed.success) {
+    return { success: false, error: "Invalid image cleanup request" };
+  }
+
+  const invalidPath = parsed.data.find((path) => !path.startsWith(`${user.id}/`));
+  if (invalidPath) {
+    return { success: false, error: "Invalid image cleanup request" };
+  }
+
+  await deleteMessageImageStoragePaths(parsed.data);
+  return { success: true, data: { removed: parsed.data.length } };
 }
 
 export async function createGroupConversation(
@@ -472,6 +555,17 @@ export async function getMessages(
             profileImage: true,
           },
         },
+        attachments: {
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            imageUrl: true,
+            storagePath: true,
+            fileName: true,
+            mimeType: true,
+            sizeBytes: true,
+          },
+        },
       },
     });
 
@@ -497,7 +591,8 @@ export async function getMessages(
 
 export async function sendMessage(
   conversationId: string,
-  content: string
+  content: string,
+  attachments: MessageAttachmentInput[] = []
 ): Promise<ActionResult<{ messageId: string }>> {
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
@@ -505,8 +600,24 @@ export async function sendMessage(
   // No batch gate - messaging is cross-batch
 
   const trimmedContent = content.trim();
-  if (trimmedContent.length < 1 || trimmedContent.length > 5000) {
-    return { success: false, error: "Message content must be between 1 and 5000 characters" };
+  const parsedAttachments = MessageAttachmentsInputSchema.safeParse(attachments);
+  if (!parsedAttachments.success) {
+    return { success: false, error: "Invalid image attachment payload" };
+  }
+
+  const invalidPath = parsedAttachments.data.find(
+    (attachment) => !attachment.storagePath.startsWith(`${user.id}/`)
+  );
+  if (invalidPath) {
+    return { success: false, error: "Invalid image attachment payload" };
+  }
+
+  if (trimmedContent.length > 5000) {
+    return { success: false, error: "Message content must be 5000 characters or fewer" };
+  }
+
+  if (trimmedContent.length < 1 && parsedAttachments.data.length === 0) {
+    return { success: false, error: "Message needs text or an image" };
   }
 
   try {
@@ -524,19 +635,36 @@ export async function sendMessage(
       return { success: false, error: "You do not have access to this conversation" };
     }
 
+    const attachmentCount = parsedAttachments.data.length;
+    const previewText =
+      trimmedContent ||
+      (attachmentCount === 1 ? "📷 Photo" : `📷 ${attachmentCount} photos`);
+
     const [message] = await prisma.$transaction([
       prisma.message.create({
         data: {
           conversationId,
           senderId: user.id,
           content: trimmedContent,
+          attachments:
+            parsedAttachments.data.length > 0
+              ? {
+                  create: parsedAttachments.data.map((attachment) => ({
+                    imageUrl: attachment.imageUrl,
+                    storagePath: attachment.storagePath,
+                    fileName: attachment.fileName || null,
+                    mimeType: attachment.mimeType || null,
+                    sizeBytes: attachment.sizeBytes ?? null,
+                  })),
+                }
+              : undefined,
         },
         select: { id: true },
       }),
       prisma.conversation.update({
         where: { id: conversationId },
         data: {
-          lastMessage: trimmedContent.substring(0, 200),
+          lastMessage: previewText.substring(0, 200),
           lastMessageAt: new Date(),
         },
         select: { id: true },

--- a/founder-sprint/src/app/(dashboard)/messages/ConversationThread.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/ConversationThread.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { format, isToday, isYesterday, isSameDay } from "date-fns";
-import type { ConversationDetail, MessageItem } from "@/actions/messaging";
+import type { ConversationDetail, MessageAttachmentInput, MessageItem } from "@/actions/messaging";
 import MessageBubble from "./MessageBubble";
 import MessageComposer from "./MessageComposer";
 import { Avatar } from "@/components/ui/Avatar";
@@ -13,7 +13,10 @@ interface ConversationThreadProps {
   conversationDetail: ConversationDetail | null;
   messages: MessageItem[];
   currentUserId: string;
-  onSendMessage: (content: string) => void;
+  onSendMessage: (
+    content: string,
+    attachments: MessageAttachmentInput[]
+  ) => boolean | Promise<boolean>;
   isLoading: boolean;
 }
 

--- a/founder-sprint/src/app/(dashboard)/messages/MessageBubble.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessageBubble.tsx
@@ -3,6 +3,7 @@
 import { format } from "date-fns";
 import type { MessageItem } from "@/actions/messaging";
 import { Avatar } from "@/components/ui/Avatar";
+import MessageImageGrid from "./MessageImageGrid";
 
 interface MessageBubbleProps {
   message: MessageItem;
@@ -20,6 +21,8 @@ export default function MessageBubble({
   const formatTime = (date: Date) => {
     return format(new Date(date), "h:mm a");
   };
+  const hasText = message.content.trim().length > 0;
+  const hasAttachments = message.attachments.length > 0;
 
   // System message (no sender)
   if (!message.sender) {
@@ -78,20 +81,26 @@ export default function MessageBubble({
           </div>
         )}
 
+        {hasAttachments && (
+          <MessageImageGrid images={message.attachments} isOwn={isOwn} />
+        )}
+
         {/* Message Bubble */}
-        <div
-          style={{
-            backgroundColor: isOwn ? "#1A1A1A" : "#f1eadd",
-            color: isOwn ? "#FFFFFF" : "#2F2C26",
-            borderRadius: isOwn ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
-            padding: "10px 14px",
-            fontSize: "14px",
-            lineHeight: "1.5",
-            wordBreak: "break-word",
-          }}
-        >
-          {message.content}
-        </div>
+        {hasText && (
+          <div
+            style={{
+              backgroundColor: isOwn ? "#1A1A1A" : "#f1eadd",
+              color: isOwn ? "#FFFFFF" : "#2F2C26",
+              borderRadius: isOwn ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
+              padding: "10px 14px",
+              fontSize: "14px",
+              lineHeight: "1.5",
+              wordBreak: "break-word",
+            }}
+          >
+            {message.content}
+          </div>
+        )}
 
         {/* Timestamp */}
         <div

--- a/founder-sprint/src/app/(dashboard)/messages/MessageComposer.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessageComposer.tsx
@@ -1,28 +1,91 @@
 "use client";
 
-import { useState, useRef, KeyboardEvent } from "react";
+/* eslint-disable @next/next/no-img-element -- composer previews use local blob URLs before upload. */
+
+import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
+import { cleanupUploadedMessageImages } from "@/actions/messaging";
+import type { MessageAttachmentInput } from "@/actions/messaging";
+import { uploadMessageImages } from "@/lib/message-image-upload";
+import {
+  MESSAGE_IMAGE_ALLOWED_TYPES,
+  MESSAGE_IMAGE_MAX_FILES,
+  validateMessageImageFiles,
+} from "@/lib/message-images";
+
+interface SelectedImage {
+  file: File;
+  previewUrl: string;
+}
 
 interface MessageComposerProps {
-  onSend: (content: string) => void | Promise<void>;
+  onSend: (
+    content: string,
+    attachments: MessageAttachmentInput[]
+  ) => boolean | Promise<boolean>;
   disabled: boolean;
 }
 
 export default function MessageComposer({ onSend, disabled }: MessageComposerProps) {
   const [message, setMessage] = useState("");
+  const [images, setImages] = useState<SelectedImage[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const sendingRef = useRef(false);
+  const imagesRef = useRef<SelectedImage[]>([]);
+
+  useEffect(() => {
+    imagesRef.current = images;
+  }, [images]);
+
+  useEffect(() => {
+    return () => {
+      imagesRef.current.forEach((image) => URL.revokeObjectURL(image.previewUrl));
+    };
+  }, []);
+
+  const clearImages = () => {
+    images.forEach((image) => URL.revokeObjectURL(image.previewUrl));
+    setImages([]);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
 
   const handleSend = async () => {
     const trimmed = message.trim();
-    if (!trimmed || disabled || sendingRef.current) return;
+    if ((!trimmed && images.length === 0) || disabled || sendingRef.current) return;
 
     sendingRef.current = true;
     setIsSending(true);
+    setError(null);
+
+    let uploadedAttachments: MessageAttachmentInput[] = [];
 
     try {
-      await onSend(trimmed);
+      if (images.length > 0) {
+        const uploadResult = await uploadMessageImages(images.map((image) => image.file));
+        if (!uploadResult.success) {
+          setError(uploadResult.error);
+          return;
+        }
+        uploadedAttachments = uploadResult.data;
+      }
+
+      const sent = await onSend(trimmed, uploadedAttachments);
+      if (!sent) {
+        if (uploadedAttachments.length > 0) {
+          await cleanupUploadedMessageImages(
+            uploadedAttachments.map((attachment) => attachment.storagePath)
+          ).catch(() => {});
+        }
+        setError("Message could not be sent. Please try again.");
+        return;
+      }
+
       setMessage("");
+      clearImages();
 
       // Reset textarea height
       if (textareaRef.current) {
@@ -41,9 +104,9 @@ export default function MessageComposer({ onSend, disabled }: MessageComposerPro
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
-    
+
     // Auto-grow textarea (max 4 lines)
     const textarea = e.target;
     textarea.style.height = "auto";
@@ -53,24 +116,165 @@ export default function MessageComposer({ onSend, disabled }: MessageComposerPro
     textarea.style.height = `${newHeight}px`;
   };
 
-  const canSend = message.trim().length > 0 && !disabled && !isSending;
+  const handleImageSelect = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files || []);
+    if (selectedFiles.length === 0) return;
+
+    const validationError = validateMessageImageFiles(
+      selectedFiles,
+      images.length
+    );
+    if (validationError) {
+      setError(validationError);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    setError(null);
+    setImages((current) => [
+      ...current,
+      ...selectedFiles.map((file) => ({
+        file,
+        previewUrl: URL.createObjectURL(file),
+      })),
+    ]);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const removeImage = (index: number) => {
+    setImages((current) => {
+      const removed = current[index];
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return current.filter((_, itemIndex) => itemIndex !== index);
+    });
+  };
+
+  const canSend = (message.trim().length > 0 || images.length > 0) && !disabled && !isSending;
+  const canAttachMore = images.length < MESSAGE_IMAGE_MAX_FILES && !disabled && !isSending;
 
   return (
     <div
       style={{
         borderTop: "1px solid #e0e0e0",
         backgroundColor: "#FFFFFF",
-        padding: "12px 16px",
+        padding: "10px 16px 12px",
       }}
     >
+      {images.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            gap: "8px",
+            overflowX: "auto",
+            padding: "0 0 10px",
+          }}
+        >
+          {images.map((image, index) => (
+            <div
+              key={image.previewUrl}
+              style={{
+                position: "relative",
+                width: "68px",
+                height: "68px",
+                borderRadius: "12px",
+                overflow: "hidden",
+                border: "1px solid #e0e0e0",
+                backgroundColor: "#f3f4f6",
+                flex: "0 0 auto",
+              }}
+            >
+              <img
+                src={image.previewUrl}
+                alt={`Selected image ${index + 1}`}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+              <button
+                type="button"
+                aria-label="Remove selected image"
+                onClick={() => removeImage(index)}
+                disabled={isSending}
+                style={{
+                  position: "absolute",
+                  top: "4px",
+                  right: "4px",
+                  width: "20px",
+                  height: "20px",
+                  borderRadius: "50%",
+                  border: "none",
+                  backgroundColor: "rgba(0, 0, 0, 0.72)",
+                  color: "#FFFFFF",
+                  cursor: isSending ? "not-allowed" : "pointer",
+                  lineHeight: 1,
+                  fontSize: "14px",
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ color: "#C62828", fontSize: "12px", marginBottom: "8px" }}>
+          {error}
+        </div>
+      )}
+
       <div className="flex" style={{ alignItems: "flex-end", gap: "8px" }}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={MESSAGE_IMAGE_ALLOWED_TYPES.join(",")}
+          multiple
+          onChange={handleImageSelect}
+          style={{ display: "none" }}
+        />
+
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!canAttachMore}
+          aria-label="Attach images"
+          style={{
+            width: "36px",
+            height: "36px",
+            borderRadius: "50%",
+            backgroundColor: "#f3f4f6",
+            border: "none",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: canAttachMore ? "pointer" : "not-allowed",
+            opacity: canAttachMore ? 1 : 0.35,
+            flexShrink: 0,
+          }}
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+            <path
+              d="M3 13.2L6.8 9.4C7.2 9 7.9 9 8.3 9.4L10 11.1L10.8 10.3C11.2 9.9 11.9 9.9 12.3 10.3L15 13"
+              stroke="#2F2C26"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <rect x="2.5" y="3" width="13" height="12" rx="2.5" stroke="#2F2C26" strokeWidth="1.5" />
+            <circle cx="12.5" cy="6.5" r="1" fill="#2F2C26" />
+          </svg>
+        </button>
+
         {/* Input */}
         <textarea
           ref={textareaRef}
           value={message}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          placeholder="Type a message..."
+          placeholder={images.length > 0 ? "Add a message..." : "Type a message..."}
           disabled={disabled || isSending}
           rows={1}
           style={{
@@ -111,17 +315,36 @@ export default function MessageComposer({ onSend, disabled }: MessageComposerPro
           }}
           aria-label="Send message"
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <path
-              d="M14 2L7 9M14 2L9.5 14L7 9M14 2L2 6.5L7 9"
-              stroke="#FFFFFF"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+          {isSending ? (
+            <div
+              aria-hidden="true"
+              style={{
+                width: "14px",
+                height: "14px",
+                border: "2px solid rgba(255, 255, 255, 0.5)",
+                borderTop: "2px solid #FFFFFF",
+                borderRadius: "50%",
+                animation: "spin 0.8s linear infinite",
+              }}
             />
-          </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M14 2L7 9M14 2L9.5 14L7 9M14 2L2 6.5L7 9"
+                stroke="#FFFFFF"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
         </button>
       </div>
+      <style>{`
+        @keyframes spin {
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
     </div>
   );
 }

--- a/founder-sprint/src/app/(dashboard)/messages/MessageImageGrid.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessageImageGrid.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element -- Supabase public images and lightbox need unconstrained rendering. */
+
+import { useEffect, useState } from "react";
+import type { MessageAttachmentItem } from "@/actions/messaging";
+
+interface MessageImageGridProps {
+  images: MessageAttachmentItem[];
+  isOwn: boolean;
+}
+
+export default function MessageImageGrid({ images, isOwn }: MessageImageGridProps) {
+  const [activeImageIndex, setActiveImageIndex] = useState<number | null>(null);
+  const hasMultipleImages = images.length > 1;
+  const activeImage = activeImageIndex === null ? null : images[activeImageIndex];
+
+  useEffect(() => {
+    if (activeImageIndex === null) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setActiveImageIndex(null);
+        return;
+      }
+
+      if (!hasMultipleImages) return;
+
+      if (event.key === "ArrowLeft") {
+        setActiveImageIndex((current) => {
+          if (current === null) return current;
+          return current === 0 ? images.length - 1 : current - 1;
+        });
+      }
+
+      if (event.key === "ArrowRight") {
+        setActiveImageIndex((current) => {
+          if (current === null) return current;
+          return current === images.length - 1 ? 0 : current + 1;
+        });
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [activeImageIndex, hasMultipleImages, images.length]);
+
+  if (images.length === 0) return null;
+
+  const isSingle = images.length === 1;
+  const isPair = images.length === 2;
+  const isRail = images.length >= 3;
+
+  return (
+    <>
+      <div
+        aria-label={`${images.length} message image${images.length === 1 ? "" : "s"}`}
+        style={{
+          display: isRail ? "flex" : "grid",
+          gridTemplateColumns: isPair ? "repeat(2, minmax(0, 1fr))" : "1fr",
+          gap: "6px",
+          width: isSingle ? "min(280px, 58vw)" : "min(360px, 58vw)",
+          overflowX: isRail ? "auto" : undefined,
+          overflowY: isRail ? "hidden" : undefined,
+          paddingBottom: isRail ? "2px" : undefined,
+          scrollSnapType: isRail ? "x proximity" : undefined,
+          scrollbarWidth: isRail ? "thin" : undefined,
+        }}
+      >
+        {images.map((image, index) => (
+          <div
+            key={image.id || image.imageUrl}
+            role="button"
+            tabIndex={0}
+            onClick={() => setActiveImageIndex(index)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setActiveImageIndex(index);
+              }
+            }}
+            style={{
+              borderRadius: isPair ? "12px" : "14px",
+              overflow: "hidden",
+              border: "1px solid #E8E1D4",
+              backgroundColor: isOwn ? "#242424" : "#F6F2EA",
+              cursor: "zoom-in",
+              aspectRatio: isSingle || isRail ? "4 / 3" : "1 / 1",
+              height: isPair ? "clamp(120px, 18vw, 170px)" : undefined,
+              width: isRail ? "clamp(150px, 30vw, 190px)" : undefined,
+              flex: isRail ? "0 0 auto" : undefined,
+              scrollSnapAlign: isRail ? "start" : undefined,
+            }}
+          >
+            <img
+              src={image.imageUrl}
+              alt={image.fileName || `Message image ${index + 1}`}
+              style={{
+                display: "block",
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+                objectPosition: "center",
+              }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {activeImage && activeImageIndex !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Message image ${activeImageIndex + 1} of ${images.length}`}
+          onClick={() => setActiveImageIndex(null)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1000,
+            backgroundColor: "rgba(18, 17, 15, 0.88)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "24px",
+            cursor: "zoom-out",
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Close image preview"
+            onClick={() => setActiveImageIndex(null)}
+            style={{
+              position: "absolute",
+              top: "18px",
+              right: "18px",
+              width: "38px",
+              height: "38px",
+              borderRadius: "50%",
+              border: "1px solid rgba(255, 255, 255, 0.22)",
+              backgroundColor: "rgba(255, 255, 255, 0.12)",
+              color: "white",
+              fontSize: "24px",
+              lineHeight: 1,
+              cursor: "pointer",
+            }}
+          >
+            ×
+          </button>
+
+          {hasMultipleImages && (
+            <button
+              type="button"
+              aria-label="Previous image"
+              onClick={(event) => {
+                event.stopPropagation();
+                setActiveImageIndex((current) => {
+                  if (current === null) return current;
+                  return current === 0 ? images.length - 1 : current - 1;
+                });
+              }}
+              style={{
+                position: "absolute",
+                left: "18px",
+                width: "42px",
+                height: "42px",
+                borderRadius: "50%",
+                border: "1px solid rgba(255, 255, 255, 0.22)",
+                backgroundColor: "rgba(255, 255, 255, 0.12)",
+                color: "white",
+                fontSize: "28px",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              ‹
+            </button>
+          )}
+
+          <img
+            src={activeImage.imageUrl}
+            alt={activeImage.fileName || `Message image ${activeImageIndex + 1} expanded`}
+            onClick={(event) => event.stopPropagation()}
+            style={{
+              maxWidth: "min(100%, 1120px)",
+              maxHeight: "90vh",
+              width: "auto",
+              height: "auto",
+              objectFit: "contain",
+              borderRadius: "12px",
+              boxShadow: "0 20px 60px rgba(0, 0, 0, 0.35)",
+              cursor: "default",
+            }}
+          />
+
+          {hasMultipleImages && (
+            <button
+              type="button"
+              aria-label="Next image"
+              onClick={(event) => {
+                event.stopPropagation();
+                setActiveImageIndex((current) => {
+                  if (current === null) return current;
+                  return current === images.length - 1 ? 0 : current + 1;
+                });
+              }}
+              style={{
+                position: "absolute",
+                right: "18px",
+                width: "42px",
+                height: "42px",
+                borderRadius: "50%",
+                border: "1px solid rgba(255, 255, 255, 0.22)",
+                backgroundColor: "rgba(255, 255, 255, 0.12)",
+                color: "white",
+                fontSize: "28px",
+                lineHeight: 1,
+                cursor: "pointer",
+              }}
+            >
+              ›
+            </button>
+          )}
+
+          {hasMultipleImages && (
+            <div
+              style={{
+                position: "absolute",
+                bottom: "18px",
+                left: "50%",
+                transform: "translateX(-50%)",
+                padding: "5px 10px",
+                borderRadius: "999px",
+                backgroundColor: "rgba(255, 255, 255, 0.14)",
+                color: "white",
+                fontSize: "12px",
+                fontWeight: 600,
+              }}
+            >
+              {activeImageIndex + 1} / {images.length}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { getUserConversations, getConversation, getMessages, sendMessage, deleteConversation, markConversationRead, searchConversations, getAllUsersForMessaging } from "@/actions/messaging";
-import type { ConversationListItem, ConversationDetail, MessageItem } from "@/actions/messaging";
+import { getUserConversations, getConversation, getMessages, sendMessage, deleteConversation, markConversationRead, searchConversations, getAllUsersForMessaging, getOrCreateDMConversation } from "@/actions/messaging";
+import type { ConversationListItem, ConversationDetail, MessageAttachmentInput, MessageItem } from "@/actions/messaging";
 import ConversationList from "./ConversationList";
 import ConversationThread from "./ConversationThread";
 import BrowseGroupsModal from "./BrowseGroupsModal";
 import CreateGroupModal from "./CreateGroupModal";
 import EditGroupModal from "./EditGroupModal";
+import NewDirectMessageModal from "./NewDirectMessageModal";
 
 interface MessagesClientProps {
   conversations: ConversationListItem[];
@@ -21,13 +22,11 @@ interface MessagesClientProps {
 export default function MessagesClient({
   conversations: initialConversations,
   currentUserId,
-  currentUserName,
-  currentUserImage,
   allUsers,
 }: MessagesClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
-  
+
   const [conversations, setConversations] = useState<ConversationListItem[]>(initialConversations);
   const [selectedConversationId, setSelectedConversationId] = useState<string | null>(
     searchParams.get("conversation")
@@ -38,6 +37,7 @@ export default function MessagesClient({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<ConversationListItem[] | null>(null);
   const [browseGroupsOpen, setBrowseGroupsOpen] = useState(false);
+  const [newDirectMessageOpen, setNewDirectMessageOpen] = useState(false);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
   const [editGroupId, setEditGroupId] = useState<string | null>(null);
   const [fetchedUsers, setFetchedUsers] = useState(allUsers);
@@ -67,17 +67,16 @@ export default function MessagesClient({
   // Debounced server-side search
   useEffect(() => {
     if (!searchQuery.trim()) {
-      setSearchResults(null);
       return;
     }
-    
+
     const timer = setTimeout(async () => {
       const result = await searchConversations(searchQuery);
       if (result.success) {
         setSearchResults(result.data);
       }
     }, 300);
-    
+
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
@@ -118,7 +117,7 @@ export default function MessagesClient({
 
     // Mark as read
     await markConversationRead(conversationId);
-    
+
     // Update the unread count in the local conversations list
     setConversations(prev =>
       prev.map(c =>
@@ -127,18 +126,32 @@ export default function MessagesClient({
     );
   };
 
-  const handleSendMessage = async (content: string) => {
-    if (!selectedConversationId) return;
+  const handleSendMessage = async (
+    content: string,
+    attachments: MessageAttachmentInput[]
+  ): Promise<boolean> => {
+    if (!selectedConversationId) return false;
 
-    const result = await sendMessage(selectedConversationId, content);
-    
-    if (result.success) {
-      // Immediately fetch updated messages
-      const messagesResult = await getMessages(selectedConversationId);
-      if (messagesResult.success) {
-        setMessages(messagesResult.data.messages);
-      }
+    const result = await sendMessage(selectedConversationId, content, attachments);
+
+    if (!result.success) {
+      window.alert(result.error);
+      return false;
     }
+
+    // Immediately fetch updated messages and conversation list
+    const [messagesResult, conversationsResult] = await Promise.all([
+      getMessages(selectedConversationId),
+      getUserConversations(),
+    ]);
+    if (messagesResult.success) {
+      setMessages(messagesResult.data.messages);
+    }
+    if (conversationsResult.success) {
+      setConversations(conversationsResult.data);
+    }
+
+    return true;
   };
 
   const handleDeleteConversation = async (conversationId: string) => {
@@ -163,7 +176,7 @@ export default function MessagesClient({
   };
 
   const handleComposeClick = () => {
-    setCreateGroupOpen(true);
+    setNewDirectMessageOpen(true);
   };
 
   const handleBrowseGroupsClick = () => {
@@ -216,6 +229,23 @@ export default function MessagesClient({
     await handleSelectConversation(conversationId);
   };
 
+  const handleStartDirectMessage = async (targetUserId: string) => {
+    const result = await getOrCreateDMConversation(targetUserId);
+    if (!result.success) {
+      window.alert(result.error);
+      return;
+    }
+
+    setNewDirectMessageOpen(false);
+
+    const conversationsResult = await getUserConversations();
+    if (conversationsResult.success) {
+      setConversations(conversationsResult.data);
+    }
+
+    await handleSelectConversation(result.data.conversationId);
+  };
+
   return (
     <div className="flex" style={{ height: "calc(100vh - 56px)" }}>
       <div style={{ width: "320px", borderRight: "1px solid #e0e0e0" }}>
@@ -228,7 +258,12 @@ export default function MessagesClient({
           onEditGroup={handleEditGroup}
           onComposeClick={handleComposeClick}
           onBrowseGroupsClick={handleBrowseGroupsClick}
-          onSearchChange={setSearchQuery}
+          onSearchChange={(query) => {
+            setSearchQuery(query);
+            if (!query.trim()) {
+              setSearchResults(null);
+            }
+          }}
           searchQuery={searchQuery}
         />
       </div>
@@ -247,6 +282,16 @@ export default function MessagesClient({
         isOpen={browseGroupsOpen}
         onClose={() => setBrowseGroupsOpen(false)}
         onJoinGroup={handleJoinGroup}
+      />
+      <NewDirectMessageModal
+        isOpen={newDirectMessageOpen}
+        onClose={() => setNewDirectMessageOpen(false)}
+        users={fetchedUsers}
+        onStartConversation={handleStartDirectMessage}
+        onCreateGroupClick={() => {
+          setNewDirectMessageOpen(false);
+          setCreateGroupOpen(true);
+        }}
       />
       <CreateGroupModal
         isOpen={createGroupOpen}

--- a/founder-sprint/src/app/(dashboard)/messages/NewDirectMessageModal.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/NewDirectMessageModal.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Avatar } from "@/components/ui/Avatar";
+
+interface MessagingUser {
+  id: string;
+  name: string | null;
+  profileImage: string | null;
+}
+
+interface NewDirectMessageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  users: MessagingUser[];
+  onStartConversation: (userId: string) => void | Promise<void>;
+  onCreateGroupClick: () => void;
+}
+
+export default function NewDirectMessageModal({
+  isOpen,
+  onClose,
+  users,
+  onStartConversation,
+  onCreateGroupClick,
+}: NewDirectMessageModalProps) {
+  const [query, setQuery] = useState("");
+  const [startingUserId, setStartingUserId] = useState<string | null>(null);
+
+  const filteredUsers = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const sortedUsers = [...users].sort((a, b) =>
+      (a.name || "Unnamed user").localeCompare(b.name || "Unnamed user")
+    );
+
+    if (!normalizedQuery) return sortedUsers;
+
+    return sortedUsers.filter((user) =>
+      (user.name || "Unnamed user").toLowerCase().includes(normalizedQuery)
+    );
+  }, [query, users]);
+
+  if (!isOpen) return null;
+
+  const handleStart = async (userId: string) => {
+    if (startingUserId) return;
+    setStartingUserId(userId);
+    try {
+      await onStartConversation(userId);
+    } finally {
+      setStartingUserId(null);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Start a direct message"
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        backgroundColor: "rgba(18, 17, 15, 0.32)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+      }}
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          width: "min(440px, 100%)",
+          maxHeight: "min(640px, 90vh)",
+          backgroundColor: "#FFFFFF",
+          border: "1px solid #e0e0e0",
+          borderRadius: "14px",
+          boxShadow: "0 18px 60px rgba(0, 0, 0, 0.18)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          className="flex"
+          style={{
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "16px 18px 12px",
+            borderBottom: "1px solid #f1eadd",
+          }}
+        >
+          <div>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: "22px",
+                fontWeight: 600,
+                color: "#2F2C26",
+                fontFamily: '"Libre Caslon Condensed", Georgia, serif',
+              }}
+            >
+              New message
+            </h2>
+            <p style={{ margin: "4px 0 0", color: "#777", fontSize: "13px" }}>
+              Pick a founder and open a direct chat.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              width: "32px",
+              height: "32px",
+              borderRadius: "50%",
+              border: "none",
+              backgroundColor: "#f3f4f6",
+              color: "#666",
+              cursor: "pointer",
+              fontSize: "20px",
+              lineHeight: 1,
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div style={{ padding: "12px 16px" }}>
+          <input
+            autoFocus
+            type="text"
+            placeholder="Search founders"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            style={{
+              width: "100%",
+              height: "38px",
+              backgroundColor: "#f3f4f6",
+              border: "none",
+              borderRadius: "10px",
+              padding: "0 12px",
+              fontSize: "14px",
+              color: "#2F2C26",
+              outline: "none",
+            }}
+          />
+        </div>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "0 8px 8px" }}>
+          {filteredUsers.length === 0 ? (
+            <div
+              style={{
+                color: "#999",
+                fontSize: "14px",
+                textAlign: "center",
+                padding: "32px 12px",
+              }}
+            >
+              No founders found
+            </div>
+          ) : (
+            filteredUsers.map((user) => (
+              <button
+                key={user.id}
+                type="button"
+                onClick={() => void handleStart(user.id)}
+                disabled={Boolean(startingUserId)}
+                style={{
+                  width: "100%",
+                  border: "none",
+                  backgroundColor: "transparent",
+                  borderRadius: "10px",
+                  padding: "10px",
+                  cursor: startingUserId ? "wait" : "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "12px",
+                  textAlign: "left",
+                  opacity: startingUserId && startingUserId !== user.id ? 0.55 : 1,
+                }}
+                onMouseEnter={(event) => {
+                  event.currentTarget.style.backgroundColor = "#fefaf3";
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.backgroundColor = "transparent";
+                }}
+              >
+                <Avatar src={user.profileImage} name={user.name} size={40} />
+                <div style={{ minWidth: 0 }}>
+                  <div
+                    style={{
+                      color: "#2F2C26",
+                      fontSize: "15px",
+                      fontWeight: 600,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {user.name || "Unnamed user"}
+                  </div>
+                  <div style={{ color: "#999", fontSize: "12px" }}>
+                    {startingUserId === user.id ? "Opening..." : "Start direct message"}
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div
+          className="flex"
+          style={{
+            padding: "12px 16px 16px",
+            borderTop: "1px solid #f1eadd",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: "12px",
+          }}
+        >
+          <span style={{ color: "#777", fontSize: "13px" }}>Need more than one person?</span>
+          <button
+            type="button"
+            onClick={onCreateGroupClick}
+            style={{
+              border: "1px solid #e0e0e0",
+              backgroundColor: "#FFFFFF",
+              borderRadius: "8px",
+              padding: "8px 12px",
+              color: "#2F2C26",
+              cursor: "pointer",
+              fontSize: "13px",
+              fontWeight: 600,
+            }}
+          >
+            Create group
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/founder-sprint/src/lib/message-image-upload.ts
+++ b/founder-sprint/src/lib/message-image-upload.ts
@@ -1,0 +1,92 @@
+import { cleanupUploadedMessageImages } from "@/actions/messaging";
+import {
+  MESSAGE_IMAGE_BUCKET,
+  MESSAGE_IMAGE_MAX_FILES,
+  type MessageImageUploadPayload,
+  validateMessageImageFiles,
+} from "@/lib/message-images";
+
+interface UploadRouteSuccess {
+  success: true;
+  url: string;
+  fileName?: string;
+  path: string;
+}
+
+interface UploadRouteFailure {
+  success: false;
+  error?: string;
+}
+
+type UploadRouteResponse = UploadRouteSuccess | UploadRouteFailure;
+
+export async function uploadMessageImages(
+  files: File[]
+): Promise<
+  | { success: true; data: MessageImageUploadPayload[] }
+  | { success: false; error: string }
+> {
+  if (files.length === 0) {
+    return { success: true, data: [] };
+  }
+
+  if (files.length > MESSAGE_IMAGE_MAX_FILES) {
+    return {
+      success: false,
+      error: `You can upload up to ${MESSAGE_IMAGE_MAX_FILES} images per message.`,
+    };
+  }
+
+  const validationError = validateMessageImageFiles(files);
+  if (validationError) {
+    return { success: false, error: validationError };
+  }
+
+  const uploaded: MessageImageUploadPayload[] = [];
+
+  try {
+    for (const file of files) {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("bucket", MESSAGE_IMAGE_BUCKET);
+
+      const response = await fetch("/api/upload", {
+        method: "POST",
+        body: formData,
+      });
+
+      const result = (await response.json()) as UploadRouteResponse;
+
+      if (!response.ok || !result.success || !result.path || !result.url) {
+        if (uploaded.length > 0) {
+          await cleanupUploadedMessageImages(uploaded.map((item) => item.storagePath)).catch(
+            () => {}
+          );
+        }
+
+        return {
+          success: false,
+          error: ("error" in result && result.error) || `Failed to upload ${file.name}.`,
+        };
+      }
+
+      uploaded.push({
+        imageUrl: result.url,
+        storagePath: result.path,
+        fileName: result.fileName || file.name,
+        mimeType: file.type || null,
+        sizeBytes: file.size,
+      });
+    }
+
+    return { success: true, data: uploaded };
+  } catch {
+    if (uploaded.length > 0) {
+      await cleanupUploadedMessageImages(uploaded.map((item) => item.storagePath)).catch(
+        () => {}
+      );
+    }
+
+    return { success: false, error: "Image upload failed. Please try again." };
+  }
+}

--- a/founder-sprint/src/lib/message-images.ts
+++ b/founder-sprint/src/lib/message-images.ts
@@ -1,0 +1,45 @@
+// Reuse the existing public image bucket so message images do not require
+// a separate Supabase storage bucket rollout.
+export const MESSAGE_IMAGE_BUCKET = "post-images";
+export const MESSAGE_IMAGE_MAX_FILES = 5;
+export const MESSAGE_IMAGE_MAX_SIZE_BYTES = 5 * 1024 * 1024;
+export const MESSAGE_IMAGE_ALLOWED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export interface MessageImageUploadPayload {
+  imageUrl: string;
+  storagePath: string;
+  fileName?: string | null;
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+}
+
+export function validateMessageImageFiles(
+  incomingFiles: File[],
+  existingCount: number = 0
+): string | null {
+  if (existingCount + incomingFiles.length > MESSAGE_IMAGE_MAX_FILES) {
+    return `You can upload up to ${MESSAGE_IMAGE_MAX_FILES} images per message.`;
+  }
+
+  const invalidType = incomingFiles.find(
+    (file) =>
+      !MESSAGE_IMAGE_ALLOWED_TYPES.includes(
+        file.type as (typeof MESSAGE_IMAGE_ALLOWED_TYPES)[number]
+      )
+  );
+  if (invalidType) {
+    return "Only JPEG, PNG, GIF, and WebP images are allowed.";
+  }
+
+  const oversized = incomingFiles.find((file) => file.size > MESSAGE_IMAGE_MAX_SIZE_BYTES);
+  if (oversized) {
+    return "Each image must be 5MB or smaller.";
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Pull request overview
Adds image support to Messages and makes starting direct chats with other founders discoverable from the Messages sidebar.

## Changes
- Persist message image attachments in a new `message_attachments` table and include them in `getMessages`.
- Allow `sendMessage` to send text, images, or text + images, with validated attachment metadata and image-only conversation previews like `📷 Photo`.
- Add client upload helpers for message images using the existing `post-images` storage bucket to avoid a new Supabase bucket rollout.
- Add image previews in the composer, cleanup of uploaded images if send fails, compact message image rendering, and click-to-expand lightbox navigation.
- Change the sidebar compose button into a “New message” founder picker while still offering “Create group” from that modal.

## Validation
- `npx prisma generate`
- `npx prisma validate`
- `npx tsc --noEmit`
- `npx eslint 'src/actions/messaging.ts' 'src/app/(dashboard)/messages/*.tsx' 'src/lib/message-image-upload.ts' 'src/lib/message-images.ts'`
- `git diff --check`

## Notes / risks
- The migration adds the DB table; deploy needs migrations applied before image attachments can be stored.
- Message images intentionally reuse the existing `post-images` bucket. If we later want a separate `message-images` bucket, Supabase storage/policies must be provisioned first.
- I did not manually test live image upload against Supabase storage in the browser.
