### PR TITLE
[codex] Default feed to latest and dedupe admin users

### DIFF
--- a/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useEffect, useRef, useCallback } from "react";
+import { useState, useTransition, useEffect, useRef, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
@@ -73,6 +73,7 @@ interface BatchUser {
     name: string;
     status: string;
   };
+  allMemberships?: BatchUser[];
 }
 
 interface SourceBatchInviteCandidate {
@@ -111,6 +112,42 @@ const baseRoleOptions = [
   { value: "founder", label: "Founder" },
   { value: "co_founder", label: "Co-founder" },
 ];
+
+const membershipStatusPriority: Record<BatchUser["status"], number> = {
+  active: 0,
+  invited: 1,
+  dropped_out: 2,
+};
+
+function compareMembershipsForAllUsersView(a: BatchUser, b: BatchUser) {
+  const statusDiff = membershipStatusPriority[a.status] - membershipStatusPriority[b.status];
+  if (statusDiff !== 0) return statusDiff;
+
+  const invitedAtDiff = new Date(b.invitedAt).getTime() - new Date(a.invitedAt).getTime();
+  if (invitedAtDiff !== 0) return invitedAtDiff;
+
+  return a.batch.name.localeCompare(b.batch.name);
+}
+
+function dedupeBatchUsersByUser(batchUsers: BatchUser[]) {
+  const membershipsByUser = new Map<string, BatchUser[]>();
+
+  for (const userBatch of batchUsers) {
+    const current = membershipsByUser.get(userBatch.userId) || [];
+    current.push(userBatch);
+    membershipsByUser.set(userBatch.userId, current);
+  }
+
+  return Array.from(membershipsByUser.values())
+    .map((memberships) => {
+      const sortedMemberships = [...memberships].sort(compareMembershipsForAllUsersView);
+      return {
+        ...sortedMemberships[0],
+        allMemberships: sortedMemberships,
+      };
+    })
+    .sort((a, b) => getDisplayName(a.user).localeCompare(getDisplayName(b.user)));
+}
 
 export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementProps) {
   const [users, setUsers] = useState<BatchUser[]>([]);
@@ -408,8 +445,8 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const renderRoleBadges = (userBatch: BatchUser) => (
     <div className="flex items-center gap-2 flex-wrap">
-      {getVisibleRoles(userBatch).map((role) => (
-        <Badge key={`${userBatch.id}-${role}`} variant="role">{getRoleDisplayName(role)}</Badge>
+      {Array.from(new Set(getDisplayMemberships(userBatch).flatMap((membership) => getVisibleRoles(membership)))).map((role) => (
+        <Badge key={`${userBatch.userId}-${role}`} variant="role">{getRoleDisplayName(role)}</Badge>
       ))}
     </div>
   );
@@ -618,16 +655,132 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     })),
   ];
 
+  const isAllUsersView = !selectedBatchId;
+  const displayUsers = useMemo(
+    () => (isAllUsersView ? dedupeBatchUsersByUser(users) : users),
+    [isAllUsersView, users]
+  );
   const selectedBatch = batches.find((b) => b.id === selectedBatchId);
   const sourceInviteBatch = batches.find((b) => b.id === sourceInviteBatchId);
   const founderChoices = users.filter((userBatch) => getVisibleRoles(userBatch).includes("founder"));
-  const isAllUsersView = !selectedBatchId;
   const userListDescription = isAllUsersView
-    ? `Showing all batch memberships (${users.length})`
-    : `Showing users in ${selectedBatch?.name || "selected batch"} (${users.length})`;
+    ? `Showing all users (${displayUsers.length})`
+    : `Showing users in ${selectedBatch?.name || "selected batch"} (${displayUsers.length})`;
+
+  const getDisplayMemberships = (userBatch: BatchUser) => userBatch.allMemberships || [userBatch];
+
+  const hasMultipleMembershipsInAllUsersView = (userBatch: BatchUser) =>
+    isAllUsersView && getDisplayMemberships(userBatch).length > 1;
 
   const renderBatchBadge = (userBatch: BatchUser) => (
-    <Badge variant="outline" size="sm">{userBatch.batch.name}</Badge>
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {getDisplayMemberships(userBatch).map((membership) => (
+        <Badge key={membership.id} variant="outline" size="sm">{membership.batch.name}</Badge>
+      ))}
+    </div>
+  );
+
+  const renderStatusBadges = (userBatch: BatchUser) => {
+    const statuses = Array.from(new Set(getDisplayMemberships(userBatch).map((membership) => membership.status)));
+
+    return (
+      <div className="flex items-center gap-2 flex-wrap">
+        {statuses.map((status) => (
+          <Badge key={`${userBatch.userId}-${status}`} variant={status === "active" ? "success" : status === "dropped_out" ? "default" : "warning"}>
+            {status}
+          </Badge>
+        ))}
+        {userBatch.user.status === "inactive" && (
+          <Badge variant="error">Deactivated</Badge>
+        )}
+      </div>
+    );
+  };
+
+  const renderMembershipManagementHint = () => (
+    <span className="text-sm text-right" style={{ color: "var(--color-foreground-secondary)" }}>
+      Filter by a batch to manage memberships.
+    </span>
+  );
+
+  const renderMembershipActions = (userBatch: BatchUser, compact = false) => (
+    hasMultipleMembershipsInAllUsersView(userBatch) ? (
+      renderMembershipManagementHint()
+    ) : (
+      <>
+        {renderRoleEditor(userBatch, compact)}
+        {userBatch.role !== "super_admin" && (
+          <div className={`flex items-center ${compact ? "" : "justify-end"} gap-2 flex-wrap`}>
+            {userBatch.status === "invited" && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleResendInvite(userBatch.userId, userBatch.batchId)}
+                  disabled={isPending}
+                >
+                  Resend Invite
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleCancelInvite(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
+                  disabled={isPending}
+                >
+                  Cancel Invite
+                </Button>
+              </>
+            )}
+            {userBatch.user.status === "inactive" ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleReactivateUser(userBatch.userId, userBatch.batchId)}
+                disabled={isPending}
+              >
+                Reactivate
+              </Button>
+            ) : userBatch.status === "dropped_out" ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleRestoreBatchUser(userBatch.userId, userBatch.batchId)}
+                disabled={isPending}
+              >
+                Restore Batch
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleDropoutUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
+                  disabled={isPending || userBatch.status !== "active"}
+                >
+                  Dropout
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => handleDeactivateUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user))}
+                  disabled={isPending}
+                >
+                  Deactivate
+                </Button>
+              </>
+            )}
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => openRemoveConfirm(userBatch)}
+              disabled={isPending}
+            >
+              Remove
+            </Button>
+          </div>
+        )}
+      </>
+    )
   );
 
   const openRemoveConfirm = (userBatch: BatchUser) => {
@@ -670,7 +823,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
             Loading users...
           </p>
         </div>
-      ) : users.length === 0 ? (
+      ) : displayUsers.length === 0 ? (
         <EmptyState
           title={isAllUsersView ? "No users found" : "No users in this batch"}
           description={isAllUsersView ? "No batch memberships found yet" : "Invite users to get started"}
@@ -690,7 +843,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
               </p>
             </div>
             <div className="md:hidden space-y-4">
-              {users.map((userBatch) => (
+              {displayUsers.map((userBatch) => (
                 <div
                   key={userBatch.id}
                   className="p-4 rounded-lg bg-white space-y-4"
@@ -722,14 +875,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                   
                   <div className="flex items-center justify-between gap-2">
                     {renderRoleBadges(userBatch)}
-                    <div className="flex items-center gap-2">
-                        <Badge variant={userBatch.status === "active" ? "success" : userBatch.status === "dropped_out" ? "default" : "warning"}>
-                          {userBatch.status}
-                        </Badge>
-                      {userBatch.user.status === "inactive" && (
-                        <Badge variant="error">Deactivated</Badge>
-                      )}
-                    </div>
+                    {renderStatusBadges(userBatch)}
                   </div>
 
                   <div className="text-sm" style={{ color: "var(--color-foreground-secondary)" }}>
@@ -737,77 +883,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                   </div>
 
                   <div className="space-y-3 pt-3 border-t" style={{ borderColor: "var(--color-card-border)" }}>
-                    {renderRoleEditor(userBatch, true)}
-                    {userBatch.role !== "super_admin" && (
-                      <div className="flex items-center gap-2 flex-wrap">
-                    {userBatch.status === "invited" && (
-                      <>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleResendInvite(userBatch.userId, userBatch.batchId)}
-                          disabled={isPending}
-                        >
-                          Resend Invite
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleCancelInvite(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
-                          disabled={isPending}
-                        >
-                          Cancel Invite
-                        </Button>
-                      </>
-                    )}
-                        {userBatch.user.status === "inactive" ? (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                        onClick={() => handleReactivateUser(userBatch.userId, userBatch.batchId)}
-                        disabled={isPending}
-                      >
-                            Reactivate
-                          </Button>
-                        ) : userBatch.status === "dropped_out" ? (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleRestoreBatchUser(userBatch.userId, userBatch.batchId)}
-                            disabled={isPending}
-                          >
-                            Restore Batch
-                          </Button>
-                        ) : (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleDropoutUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
-                              disabled={isPending || userBatch.status !== "active"}
-                            >
-                              Dropout
-                            </Button>
-                            <Button
-                              variant="danger"
-                              size="sm"
-                              onClick={() => handleDeactivateUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user))}
-                              disabled={isPending}
-                            >
-                              Deactivate
-                            </Button>
-                          </>
-                        )}
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      onClick={() => openRemoveConfirm(userBatch)}
-                      disabled={isPending}
-                    >
-                      Remove
-                    </Button>
-                      </div>
-                    )}
+                    {renderMembershipActions(userBatch, true)}
                   </div>
                 </div>
               ))}
@@ -842,7 +918,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                 </tr>
               </thead>
               <tbody>
-                {users.map((userBatch) => (
+                {displayUsers.map((userBatch) => (
                   <tr
                     key={userBatch.id}
                     style={{ borderBottom: "1px solid var(--color-card-border)" }}
@@ -876,14 +952,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                       {renderRoleBadges(userBatch)}
                     </td>
                     <td className="py-3 px-4">
-                      <div className="flex items-center gap-2">
-                        <Badge variant={userBatch.status === "active" ? "success" : userBatch.status === "dropped_out" ? "default" : "warning"}>
-                          {userBatch.status}
-                        </Badge>
-                        {userBatch.user.status === "inactive" && (
-                          <Badge variant="error">Deactivated</Badge>
-                        )}
-                      </div>
+                      {renderStatusBadges(userBatch)}
                     </td>
                     <td className="py-3 px-4">
                       <span style={{ color: "var(--color-foreground-secondary)", fontSize: "14px" }}>
@@ -892,77 +961,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     </td>
                     <td className="py-3 px-4">
                       <div className="flex flex-col items-end gap-2">
-                        {renderRoleEditor(userBatch)}
-                        {userBatch.role !== "super_admin" && (
-                          <div className="flex items-center justify-end gap-2 flex-wrap">
-                        {userBatch.status === "invited" && (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleResendInvite(userBatch.userId, userBatch.batchId)}
-                              disabled={isPending}
-                            >
-                              Resend Invite
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleCancelInvite(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
-                              disabled={isPending}
-                            >
-                              Cancel Invite
-                            </Button>
-                          </>
-                        )}
-                    {userBatch.user.status === "inactive" ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                            onClick={() => handleReactivateUser(userBatch.userId, userBatch.batchId)}
-                            disabled={isPending}
-                          >
-                        Reactivate
-                      </Button>
-                    ) : userBatch.status === "dropped_out" ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleRestoreBatchUser(userBatch.userId, userBatch.batchId)}
-                        disabled={isPending}
-                      >
-                        Restore Batch
-                      </Button>
-                    ) : (
-                      <>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleDropoutUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user), userBatch.batch.name)}
-                          disabled={isPending || userBatch.status !== "active"}
-                        >
-                          Dropout
-                        </Button>
-                        <Button
-                          variant="danger"
-                          size="sm"
-                          onClick={() => handleDeactivateUser(userBatch.userId, userBatch.batchId, getDisplayName(userBatch.user))}
-                          disabled={isPending}
-                        >
-                          Deactivate
-                        </Button>
-                      </>
-                    )}
-                        <Button
-                          variant="danger"
-                          size="sm"
-                          onClick={() => openRemoveConfirm(userBatch)}
-                          disabled={isPending}
-                        >
-                          Remove
-                        </Button>
-                          </div>
-                        )}
+                        {renderMembershipActions(userBatch)}
                       </div>
                     </td>
                   </tr>

--- a/founder-sprint/src/app/(dashboard)/feed/FeedView.tsx
+++ b/founder-sprint/src/app/(dashboard)/feed/FeedView.tsx
@@ -69,7 +69,7 @@ interface FeedViewProps {
 export function FeedView({ posts, archivedPosts = [], currentUser, isAdmin = false, initialTab, likedPostIds, bookmarkedPostIds }: FeedViewProps) {
   const router = useRouter();
   const [showArchived, setShowArchived] = useState(false);
-  const [activeTab, setActiveTab] = useState(initialTab || 'top');
+  const [activeTab, setActiveTab] = useState(initialTab || 'recent');
   const [isPending, startTransition] = useTransition();
   const [isCreatingPost, setIsCreatingPost] = useState(false);
   const toast = useToast();

--- a/founder-sprint/src/app/(dashboard)/feed/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/feed/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/permissions";
 import { getPaginatedPosts, getArchivedPosts, getUserLikedPostIds } from "@/actions/feed";
 import { getUserBookmarkedPostIds } from "@/actions/bookmark";
-import { getFollowingIdsForUser, getFollowSuggestions } from "@/actions/follow";
+import { getFollowSuggestions } from "@/actions/follow";
 import { FeedView } from "./FeedView";
 import { PeopleToFollow } from "@/components/feed/PeopleToFollow";
 import { Pagination } from "@/components/ui/Pagination";
@@ -15,15 +15,14 @@ export default async function FeedPage({ searchParams }: { searchParams: Promise
   if (!user) redirect("/login");
 
   const params = await searchParams;
-  const tab = params.tab || 'top';
+  const tab = params.tab || 'recent';
   const page = Math.max(1, parseInt(params.page || "1", 10) || 1);
   const isAdmin = user.role === "super_admin" || user.role === "admin";
 
-  const [paginatedPosts, archivedPosts, followSuggestions, followingIds] = await Promise.all([
+  const [paginatedPosts, archivedPosts, followSuggestions] = await Promise.all([
     getPaginatedPosts(page),
     isAdmin ? getArchivedPosts() : Promise.resolve([]),
     getFollowSuggestions(8),
-    getFollowingIdsForUser(user.id),
   ]);
 
   const postIds = paginatedPosts.items.map((p) => p.id);

--- a/founder-sprint/src/components/bookface/BookfaceFeedPage.tsx
+++ b/founder-sprint/src/components/bookface/BookfaceFeedPage.tsx
@@ -246,7 +246,7 @@ export const BookfaceFeedPage: React.FC<BookfaceFeedPageProps> = ({
   posts = defaultPosts,
   peopleToFollow = defaultPeopleToFollow,
 }) => {
-  const [activeTab, setActiveTab] = useState('top');
+  const [activeTab, setActiveTab] = useState('recent');
   const [following, setFollowing] = useState<Set<string>>(new Set());
   const [likedPosts, setLikedPosts] = useState<Set<string>>(new Set(['2']));
   const [bookmarkedPosts, setBookmarkedPosts] = useState<Set<string>>(new Set());
@@ -325,7 +325,7 @@ export const BookfaceFeedPage: React.FC<BookfaceFeedPageProps> = ({
           <div style={styles.newPostBox}>
             <div style={styles.newPostAvatar}>J</div>
             <div style={styles.newPostInput}>
-              What's on your mind?
+              What&apos;s on your mind?
             </div>
           </div>
 

--- a/founder-sprint/src/components/bookface/FeedTabs.tsx
+++ b/founder-sprint/src/components/bookface/FeedTabs.tsx
@@ -13,8 +13,8 @@ export interface FeedTabsProps {
 }
 
 export const defaultTabs: Tab[] = [
+  { id: 'recent', label: 'Latest' },
   { id: 'top', label: 'Top' },
-  { id: 'recent', label: 'Recent' },
   { id: 'general', label: 'General' },
   { id: 'launch', label: 'Launch' },
   { id: 'classifieds', label: 'Classifieds' },


### PR DESCRIPTION
## Pull request overview
Follow-up fixes after the messaging PR merge.

## Changes
- Default the main feed to Latest/Recent instead of Top.
- Move the Latest tab before Top while preserving the Top tab for engagement-ranked browsing.
- In Admin → Users with no batch filter selected, show each user only once even if they have multiple batch memberships.
- For multi-batch users in the all-users view, show all batch/status/role badges on the single row and require filtering to a specific batch before membership-specific actions.

## Validation
- `npx tsc --noEmit`
- `npx eslint 'src/app/(dashboard)/admin/users/UserManagement.tsx'`
- `npx eslint 'src/app/(dashboard)/feed/page.tsx' 'src/app/(dashboard)/feed/FeedView.tsx' 'src/components/bookface/FeedTabs.tsx' 'src/components/bookface/BookfaceFeedPage.tsx'`
- `git diff --check`

## Notes
- Full `npm run lint` still fails on pre-existing unrelated repository lint issues outside this change; focused lint for changed files passes.
