### PR TITLE
[codex] Refresh feed social actions

### DIFF
--- a/founder-sprint/src/app/(dashboard)/feed/[id]/PostDetailClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/feed/[id]/PostDetailClient.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, { useState, useTransition } from "react";
+import React, { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { PostCard } from "@/components/bookface/PostCard";
 import { createComment, toggleLike } from "@/actions/feed";
 import { bookmarkPost, unbookmarkPost } from "@/actions/bookmark";
 import { formatRelativeTime, getDisplayName, getInitials } from "@/lib/utils";
 import type { RenderablePostMention } from "@/components/feed/renderPostContentWithMentions";
+import { useToast } from "@/hooks/useToast";
 
 interface PostComment {
   id: string;
@@ -39,7 +40,6 @@ interface PostDetailClientProps {
   currentUser: { id: string; name: string | null; email: string; profileImage: string | null };
   isLiked: boolean;
   isBookmarked: boolean;
-  isAdmin: boolean;
   participants: Array<{ id: string; name: string | null; email: string; profileImage: string | null }>;
 }
 
@@ -170,13 +170,16 @@ const styles = {
     alignItems: 'center',
     gap: '6px',
     fontSize: '13px',
-    color: '#666',
+    color: '#3F3D3A',
     background: 'none',
     border: 'none',
     cursor: 'pointer',
-    padding: '4px 8px',
-    borderRadius: '4px',
-    transition: 'background-color 0.2s',
+    padding: '4px 2px',
+    borderRadius: '999px',
+    fontWeight: 600,
+    lineHeight: 1,
+    minHeight: '28px',
+    transition: 'color 0.16s ease, transform 0.16s ease, opacity 0.16s ease',
   },
   actionButtonActive: {
     display: 'flex',
@@ -187,9 +190,16 @@ const styles = {
     background: 'none',
     border: 'none',
     cursor: 'pointer',
-    padding: '4px 8px',
-    borderRadius: '4px',
-    transition: 'background-color 0.2s',
+    padding: '4px 2px',
+    borderRadius: '999px',
+    fontWeight: 600,
+    lineHeight: 1,
+    minHeight: '28px',
+    transition: 'color 0.16s ease, transform 0.16s ease, opacity 0.16s ease',
+  },
+  actionButtonDisabled: {
+    cursor: 'default',
+    opacity: 0.5,
   },
   repliesContainer: {
     marginTop: '16px',
@@ -269,20 +279,49 @@ const styles = {
   },
 };
 
+function HeartIcon({ filled = false, size = 20 }: { filled?: boolean; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} aria-hidden="true">
+      <path
+        d="M20.8 4.6c-2-2-5.2-1.9-7.1.2L12 6.5l-1.7-1.7C8.4 2.7 5.2 2.6 3.2 4.6c-2.2 2.2-2.1 5.8.2 8l8.6 8.1 8.6-8.1c2.3-2.2 2.4-5.8.2-8Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CommentIcon({ size = 19 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M20 11.6c0 4.2-3.6 7.6-8 7.6-1.1 0-2.1-.2-3.1-.6L4 20l1.3-4.1A7.1 7.1 0 0 1 4 11.6C4 7.4 7.6 4 12 4s8 3.4 8 7.6Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function PostDetailClient({
   post,
   currentUser,
   isLiked: initialIsLiked,
   isBookmarked: initialIsBookmarked,
-  isAdmin,
   participants,
 }: PostDetailClientProps) {
+  const toast = useToast();
   const [isPending, startTransition] = useTransition();
   const [commentInput, setCommentInput] = useState("");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyInput, setReplyInput] = useState("");
   const [isLiked, setIsLiked] = useState(initialIsLiked);
   const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked);
+  const [isShareCopied, setIsShareCopied] = useState(false);
   const [likeCount, setLikeCount] = useState(post.likes.length);
   const [commentLikes, setCommentLikes] = useState<Record<string, boolean>>(() => {
     const likes: Record<string, boolean> = {};
@@ -294,26 +333,94 @@ export function PostDetailClient({
     });
     return likes;
   });
+  const [commentLikeCounts, setCommentLikeCounts] = useState<Record<string, number>>(() => {
+    const counts: Record<string, number> = {};
+    post.comments.forEach((comment) => {
+      counts[comment.id] = comment.likes.length;
+      comment.replies?.forEach((reply) => {
+        counts[reply.id] = reply.likes.length;
+      });
+    });
+    return counts;
+  });
+  const commentSectionRef = useRef<HTMLDivElement | null>(null);
+  const commentInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const shareCopiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current);
+    };
+  }, []);
 
   const handlePostLike = () => {
+    const nextIsLiked = !isLiked;
+    setIsLiked(nextIsLiked);
+    setLikeCount((prev) => Math.max(0, prev + (nextIsLiked ? 1 : -1)));
+
     startTransition(async () => {
-      const newIsLiked = !isLiked;
-      setIsLiked(newIsLiked);
-      setLikeCount((prev) => (newIsLiked ? prev + 1 : prev - 1));
-      await toggleLike("post", post.id);
+      const result = await toggleLike("post", post.id);
+      if (!result.success) {
+        setIsLiked(!nextIsLiked);
+        setLikeCount((prev) => Math.max(0, prev + (nextIsLiked ? -1 : 1)));
+        toast.error(result.error);
+      }
     });
   };
 
   const handlePostBookmark = () => {
+    const nextIsBookmarked = !isBookmarked;
+    setIsBookmarked(nextIsBookmarked);
+
     startTransition(async () => {
-      const newIsBookmarked = !isBookmarked;
-      setIsBookmarked(newIsBookmarked);
-      if (newIsBookmarked) {
-        await bookmarkPost(post.id);
-      } else {
-        await unbookmarkPost(post.id);
+      const result = nextIsBookmarked
+        ? await bookmarkPost(post.id)
+        : await unbookmarkPost(post.id);
+
+      if (!result.success) {
+        setIsBookmarked(!nextIsBookmarked);
+        toast.error(result.error);
       }
     });
+  };
+
+  const handlePostCommentClick = () => {
+    commentSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.setTimeout(() => commentInputRef.current?.focus(), 250);
+  };
+
+  const handlePostShare = async () => {
+    const url = `${window.location.origin}/feed/${post.id}`;
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = url;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        const copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+
+        if (!copied) {
+          throw new Error("Clipboard copy command failed");
+        }
+      }
+
+      setIsShareCopied(true);
+      toast.success("Link copied to clipboard");
+      if (shareCopiedTimerRef.current) clearTimeout(shareCopiedTimerRef.current);
+      shareCopiedTimerRef.current = setTimeout(() => {
+        setIsShareCopied(false);
+      }, 2000);
+    } catch {
+      toast.error("Could not copy link");
+    }
   };
 
   const handleCommentSubmit = () => {
@@ -336,15 +443,34 @@ export function PostDetailClient({
   };
 
   const handleCommentLike = (commentId: string) => {
+    const wasLiked = commentLikes[commentId] || false;
+    const nextIsLiked = !wasLiked;
+    setCommentLikes((prev) => ({ ...prev, [commentId]: nextIsLiked }));
+    setCommentLikeCounts((prev) => ({
+      ...prev,
+      [commentId]: Math.max(0, (prev[commentId] ?? 0) + (nextIsLiked ? 1 : -1)),
+    }));
+
     startTransition(async () => {
-      setCommentLikes((prev) => ({ ...prev, [commentId]: !prev[commentId] }));
-      await toggleLike("comment", undefined, commentId);
+      const result = await toggleLike("comment", undefined, commentId);
+      if (!result.success) {
+        setCommentLikes((prev) => ({ ...prev, [commentId]: wasLiked }));
+        setCommentLikeCounts((prev) => ({
+          ...prev,
+          [commentId]: Math.max(0, (prev[commentId] ?? 0) + (nextIsLiked ? -1 : 1)),
+        }));
+        toast.error(result.error);
+      }
     });
   };
 
   const renderComment = (comment: PostComment, isReply: boolean = false) => {
     const isLikedByUser = commentLikes[comment.id] || false;
-    const likeCount = comment.likes.length;
+    const likeCount = commentLikeCounts[comment.id] ?? comment.likes.length;
+    const likeButtonStyle = {
+      ...(isLikedByUser ? styles.actionButtonActive : styles.actionButton),
+      ...(isPending ? styles.actionButtonDisabled : {}),
+    };
 
     return (
       <div key={comment.id}>
@@ -371,18 +497,22 @@ export function PostDetailClient({
           <div style={styles.commentContent}>{comment.content}</div>
           <div style={styles.commentActions}>
             <button
-              style={isLikedByUser ? styles.actionButtonActive : styles.actionButton}
+              type="button"
+              style={likeButtonStyle}
               onClick={() => handleCommentLike(comment.id)}
               disabled={isPending}
+              aria-label={isLikedByUser ? "Unlike comment" : "Like comment"}
             >
-              <span>{isLikedByUser ? "❤️" : "🤍"}</span>
+              <HeartIcon filled={isLikedByUser} />
               {likeCount > 0 && <span>{likeCount}</span>}
             </button>
             {!isReply && (
               <button
+                type="button"
                 style={styles.actionButton}
                 onClick={() => setReplyingTo(replyingTo === comment.id ? null : comment.id)}
               >
+                <CommentIcon />
                 Reply
               </button>
             )}
@@ -452,11 +582,14 @@ export function PostDetailClient({
           views={post.viewCount}
           isLiked={isLiked}
           isBookmarked={isBookmarked}
+          isShareCopied={isShareCopied}
           onLike={handlePostLike}
+          onComment={handlePostCommentClick}
           onBookmark={handlePostBookmark}
+          onShare={handlePostShare}
         />
 
-        <div style={styles.commentSection}>
+        <div ref={commentSectionRef} style={styles.commentSection}>
           <div style={styles.commentInputContainer}>
             {currentUser.profileImage ? (
               <img
@@ -471,6 +604,7 @@ export function PostDetailClient({
             )}
             <div style={styles.commentInputWrapper}>
               <textarea
+                ref={commentInputRef}
                 style={styles.textarea}
                 value={commentInput}
                 onChange={(e) => setCommentInput(e.target.value)}

--- a/founder-sprint/src/app/(dashboard)/feed/[id]/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/feed/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { redirect, notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/permissions";
 import { getPostById, getConversationParticipants } from "@/actions/post-detail";
-import { checkIsBookmarked } from "@/actions/bookmark";
 import { PostDetailClient } from "./PostDetailClient";
 export default async function PostDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const user = await getCurrentUser();
@@ -17,7 +16,6 @@ export default async function PostDetailPage({ params }: { params: Promise<{ id:
 
   const isLiked = post.likes.some((like: { userId: string }) => like.userId === user.id);
   const isBookmarked = post.bookmarks.length > 0;
-  const isAdmin = user.role === "super_admin" || user.role === "admin";
     return (
     <div>
       <div className="lg:grid lg:grid-cols-[1fr_280px] lg:gap-6">
@@ -26,7 +24,6 @@ export default async function PostDetailPage({ params }: { params: Promise<{ id:
           currentUser={user}
           isLiked={isLiked}
           isBookmarked={isBookmarked}
-          isAdmin={isAdmin}
           participants={participants}
         />
       </div>

--- a/founder-sprint/src/components/bookface/PostCard.tsx
+++ b/founder-sprint/src/components/bookface/PostCard.tsx
@@ -73,39 +73,18 @@ function CommentIcon({ size = 22 }: { size?: number }) {
   );
 }
 
-function RepostIcon({ size = 22 }: { size?: number }) {
+function ShareIcon({ size = 22 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
       <path
-        d="M7 7h9.5c1.9 0 3.5 1.6 3.5 3.5v.5M17 4l3 3-3 3"
+        d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"
         stroke="currentColor"
         strokeWidth="1.9"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
-        d="M17 17H7.5C5.6 17 4 15.4 4 13.5V13M7 20l-3-3 3-3"
-        stroke="currentColor"
-        strokeWidth="1.9"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SendIcon({ size = 22 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path
-        d="M21 3 3.8 10.5c-.9.4-.8 1.7.1 2l6.4 2.1 2.1 6.4c.3.9 1.6 1 2 .1L21 3Z"
-        stroke="currentColor"
-        strokeWidth="1.9"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="m10.4 14.6 4.9-4.9"
+        d="M16 6 12 2 8 6M12 2v13"
         stroke="currentColor"
         strokeWidth="1.9"
         strokeLinecap="round"
@@ -585,24 +564,14 @@ export const PostCard: React.FC<PostCardProps> = ({
 
         <button
           type="button"
-          style={getActionButtonStyle(false, !onShare)}
-          onClick={onShare}
-          disabled={!onShare}
-          aria-label="Copy post link"
-        >
-          <RepostIcon />
-        </button>
-
-        <button
-          type="button"
           style={getActionButtonStyle(isShareCopied, !onShare)}
           onClick={onShare}
           disabled={!onShare}
           aria-label={isShareCopied ? 'Link copied' : 'Share post'}
           aria-live="polite"
         >
-          {isShareCopied ? <CheckIcon /> : <SendIcon />}
-          {isShareCopied && <span style={{ fontSize: '12px' }}>Copied</span>}
+          {isShareCopied ? <CheckIcon /> : <ShareIcon />}
+          <span style={{ fontSize: '12px' }}>{isShareCopied ? 'Copied' : 'Share'}</span>
         </button>
 
         <button

--- a/founder-sprint/src/components/bookface/PostCard.tsx
+++ b/founder-sprint/src/components/bookface/PostCard.tsx
@@ -45,6 +45,104 @@ export interface PostCardProps {
   variant?: PostCardVariant;
 }
 
+function HeartIcon({ filled = false, size = 22 }: { filled?: boolean; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} aria-hidden="true">
+      <path
+        d="M20.8 4.6c-2-2-5.2-1.9-7.1.2L12 6.5l-1.7-1.7C8.4 2.7 5.2 2.6 3.2 4.6c-2.2 2.2-2.1 5.8.2 8l8.6 8.1 8.6-8.1c2.3-2.2 2.4-5.8.2-8Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CommentIcon({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M20 11.6c0 4.2-3.6 7.6-8 7.6-1.1 0-2.1-.2-3.1-.6L4 20l1.3-4.1A7.1 7.1 0 0 1 4 11.6C4 7.4 7.6 4 12 4s8 3.4 8 7.6Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function RepostIcon({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M7 7h9.5c1.9 0 3.5 1.6 3.5 3.5v.5M17 4l3 3-3 3"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17 17H7.5C5.6 17 4 15.4 4 13.5V13M7 20l-3-3 3-3"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function SendIcon({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M21 3 3.8 10.5c-.9.4-.8 1.7.1 2l6.4 2.1 2.1 6.4c.3.9 1.6 1 2 .1L21 3Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="m10.4 14.6 4.9-4.9"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function BookmarkIcon({ filled = false, size = 21 }: { filled?: boolean; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} aria-hidden="true">
+      <path
+        d="M6 4.5A2.5 2.5 0 0 1 8.5 2h7A2.5 2.5 0 0 1 18 4.5v16L12 17l-6 3.5v-16Z"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="m5 12 4 4L19 6"
+        stroke="currentColor"
+        strokeWidth="2.1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 function getStyles(variant: PostCardVariant) {
   const isFeed = variant === 'feed';
 
@@ -221,7 +319,7 @@ function getStyles(variant: PostCardVariant) {
     actions: {
       display: 'flex',
       alignItems: 'center',
-      gap: isFeed ? '10px' : '20px',
+      gap: isFeed ? '18px' : '20px',
       borderTop: isFeed ? '1px solid #EFE8DB' : '1px solid #f0f0f0',
       paddingTop: isFeed ? '10px' : '12px',
       flexWrap: 'wrap' as const,
@@ -229,20 +327,27 @@ function getStyles(variant: PostCardVariant) {
     actionBtn: {
       display: 'flex',
       alignItems: 'center',
+      gap: '6px',
       backgroundColor: 'transparent',
       border: 'none',
       cursor: 'pointer',
-      padding: isFeed ? '2px 4px' : '4px 6px',
-      borderRadius: '4px',
-      color: isFeed ? '#7A7468' : '#666',
-      fontSize: isFeed ? '12px' : '13px',
-      fontWeight: 500,
-      transition: 'background-color 0.2s, color 0.2s',
+      padding: isFeed ? '4px 2px' : '4px 6px',
+      borderRadius: '999px',
+      color: isFeed ? '#3F3D3A' : '#444',
+      fontSize: isFeed ? '14px' : '13px',
+      fontWeight: 600,
+      lineHeight: 1,
+      minHeight: '30px',
+      transition: 'color 0.16s ease, transform 0.16s ease, opacity 0.16s ease',
     },
     actionBtnActive: {
       color: '#2F2C26',
-      backgroundColor: isFeed ? 'transparent' : 'rgba(26, 26, 26, 0.1)',
+      backgroundColor: 'transparent',
       fontWeight: 600,
+    },
+    actionBtnDisabled: {
+      cursor: 'default',
+      opacity: 0.45,
     },
     viewCount: {
       marginLeft: 'auto',
@@ -367,6 +472,11 @@ export const PostCard: React.FC<PostCardProps> = ({
   const truncateLength = variant === 'feed' ? 240 : 280;
 
   const shouldTruncate = content.length > truncateLength;
+  const getActionButtonStyle = (active = false, disabled = false) => ({
+    ...styles.actionBtn,
+    ...(active ? styles.actionBtnActive : {}),
+    ...(disabled ? styles.actionBtnDisabled : {}),
+  });
 
   return (
     <div style={styles.card}>
@@ -453,38 +563,56 @@ export const PostCard: React.FC<PostCardProps> = ({
       <div style={styles.actions}>
         <button
           type="button"
-          style={{ ...styles.actionBtn, ...(isLiked ? styles.actionBtnActive : {}) }}
+          style={getActionButtonStyle(isLiked, !onLike)}
           onClick={onLike}
+          disabled={!onLike}
+          aria-label={isLiked ? 'Unlike post' : 'Like post'}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill={isLiked ? '#1A1A1A' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><path d="M12 19V5M5 12l7-7 7 7" /></svg>
+          <HeartIcon filled={isLiked} />
           {likes > 0 && likes}
         </button>
 
-        <button type="button" style={styles.actionBtn} onClick={onComment}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+        <button
+          type="button"
+          style={getActionButtonStyle(false, !onComment)}
+          onClick={onComment}
+          disabled={!onComment}
+          aria-label="View comments"
+        >
+          <CommentIcon />
           {comments > 0 && comments}
         </button>
 
         <button
           type="button"
-          style={{ ...styles.actionBtn, ...(isShareCopied ? styles.actionBtnActive : {}) }}
+          style={getActionButtonStyle(false, !onShare)}
           onClick={onShare}
-          aria-live="polite"
+          disabled={!onShare}
+          aria-label="Copy post link"
         >
-          {isShareCopied ? (
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><polyline points="20 6 9 17 4 12" /></svg>
-          ) : (
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" /><polyline points="16 6 12 2 8 6" /><line x1="12" y1="2" x2="12" y2="15" /></svg>
-          )}
-          {isShareCopied ? 'Copied' : 'Share'}
+          <RepostIcon />
         </button>
 
         <button
           type="button"
-          style={{ ...styles.actionBtn, ...(isBookmarked ? styles.actionBtnActive : {}) }}
-          onClick={onBookmark}
+          style={getActionButtonStyle(isShareCopied, !onShare)}
+          onClick={onShare}
+          disabled={!onShare}
+          aria-label={isShareCopied ? 'Link copied' : 'Share post'}
+          aria-live="polite"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill={isBookmarked ? '#1A1A1A' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '2px' }}><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>
+          {isShareCopied ? <CheckIcon /> : <SendIcon />}
+          {isShareCopied && <span style={{ fontSize: '12px' }}>Copied</span>}
+        </button>
+
+        <button
+          type="button"
+          style={getActionButtonStyle(isBookmarked, !onBookmark)}
+          onClick={onBookmark}
+          disabled={!onBookmark}
+          aria-label={isBookmarked ? 'Remove bookmark' : 'Bookmark post'}
+        >
+          <BookmarkIcon filled={isBookmarked} />
         </button>
 
         {views !== undefined && (


### PR DESCRIPTION
## Summary\n- Replace feed card action controls with a cleaner Threads-like heart/comment/repost/send/bookmark icon treatment.\n- Wire post detail comment/share actions so buttons no longer appear dead and share copy shows a copied state/toast.\n- Make post/comment likes and bookmarks update optimistically with rollback on server-action failure.\n\n## Verification\n- npx tsc --noEmit\n- npx eslint 'src/components/bookface/PostCard.tsx' 'src/app/(dashboard)/feed/[id]/PostDetailClient.tsx' 'src/app/(dashboard)/feed/[id]/page.tsx' (0 errors; existing <img> warnings only)\n- git diff --check\n\n## Notes\n- Full npm run lint still fails on pre-existing unrelated lint errors across dev_poc/e2e/questions/sessions/Toast/etc.; this PR did not introduce those.