### PR TITLE
[codex] Keep messages usable on mobile

### DIFF
--- a/founder-sprint/src/app/(dashboard)/messages/ConversationThread.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/ConversationThread.tsx
@@ -18,6 +18,7 @@ interface ConversationThreadProps {
     attachments: MessageAttachmentInput[]
   ) => boolean | Promise<boolean>;
   isLoading: boolean;
+  onBack?: () => void;
 }
 
 export default function ConversationThread({
@@ -27,6 +28,7 @@ export default function ConversationThread({
   currentUserId,
   onSendMessage,
   isLoading,
+  onBack,
 }: ConversationThreadProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -142,6 +144,32 @@ export default function ConversationThread({
           backgroundColor: "#FFFFFF",
         }}
       >
+        {onBack && (
+          <button
+            type="button"
+            className="messages-mobile-back"
+            onClick={onBack}
+            aria-label="Back to conversations"
+            style={{
+              width: "36px",
+              height: "36px",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "none",
+              background: "transparent",
+              color: "#2F2C26",
+              cursor: "pointer",
+              padding: 0,
+              marginLeft: "-8px",
+              flexShrink: 0,
+            }}
+          >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M15 18L9 12L15 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        )}
+
         {/* Avatar */}
         {conversationDetail?.isGroup ? (
           <GroupAvatar

--- a/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
@@ -246,9 +246,16 @@ export default function MessagesClient({
     await handleSelectConversation(result.data.conversationId);
   };
 
+  const handleBackToConversations = () => {
+    setSelectedConversationId(null);
+    setConversationDetail(null);
+    setMessages([]);
+    router.push("/messages");
+  };
+
   return (
-    <div className="flex" style={{ height: "calc(100vh - 56px)" }}>
-      <div style={{ width: "320px", borderRight: "1px solid #e0e0e0" }}>
+    <div className={`messages-shell ${selectedConversationId ? "messages-shell--has-selection" : ""}`}>
+      <div className="messages-list-pane">
         <ConversationList
           conversations={searchResults ?? conversations}
           currentUserId={currentUserId}
@@ -267,7 +274,7 @@ export default function MessagesClient({
           searchQuery={searchQuery}
         />
       </div>
-      <div className="flex" style={{ flex: 1 }}>
+      <div className="messages-thread-pane">
         <ConversationThread
           conversationId={selectedConversationId}
           conversationDetail={conversationDetail}
@@ -275,6 +282,7 @@ export default function MessagesClient({
           currentUserId={currentUserId}
           onSendMessage={handleSendMessage}
           isLoading={messagesLoading}
+          onBack={handleBackToConversations}
         />
       </div>
 
@@ -309,6 +317,55 @@ export default function MessagesClient({
           currentUserId={currentUserId}
         />
       )}
+      <style>{`
+        .messages-shell {
+          display: flex;
+          height: calc(100dvh - 48px);
+          min-width: 0;
+          overflow: hidden;
+        }
+
+        .messages-list-pane {
+          width: 320px;
+          min-width: 320px;
+          border-right: 1px solid #e0e0e0;
+        }
+
+        .messages-thread-pane {
+          display: flex;
+          flex: 1;
+          min-width: 0;
+        }
+
+        .messages-mobile-back {
+          display: none;
+        }
+
+        @media (max-width: 767px) {
+          .messages-list-pane {
+            width: 100%;
+            min-width: 0;
+            border-right: none;
+          }
+
+          .messages-thread-pane {
+            display: none;
+            width: 100%;
+          }
+
+          .messages-shell--has-selection .messages-list-pane {
+            display: none;
+          }
+
+          .messages-shell--has-selection .messages-thread-pane {
+            display: flex;
+          }
+
+          .messages-mobile-back {
+            display: inline-flex;
+          }
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Switch the Messages page to a single-pane mobile layout.
- Hide the empty conversation thread on phone widths until a conversation is selected.
- Add a mobile-only back button in the thread header so users can return to the conversation list.
- Preserve the existing desktop split-pane layout.

## Root cause
The Messages screen always rendered the fixed-width conversation list and thread side by side. On mobile this left the list squeezed and the empty thread placeholder visible, matching the broken screenshot.

## Validation
- `npx eslint src/app/(dashboard)/messages/MessagesClient.tsx src/app/(dashboard)/messages/ConversationThread.tsx`
- `npm run build`

## Notes
- Manual device/browser screenshot verification was not run.