### PR TITLE
Fix image display size build type

### DIFF
--- a/founder-sprint/src/components/feed/PostImageGrid.tsx
+++ b/founder-sprint/src/components/feed/PostImageGrid.tsx
@@ -6,7 +6,7 @@ export type PostImageDisplaySize = "small" | "medium" | "large";
 
 interface PostImageGridProps {
   images: Array<{ id?: string; imageUrl: string }>;
-  displaySize?: PostImageDisplaySize | null;
+  displaySize?: string | null;
 }
 
 const IMAGE_DISPLAY_SIZE_STYLES: Record<


### PR DESCRIPTION
## Summary
- Allow `PostImageGrid` to accept the `string | null` shape returned by Prisma for stored image display sizes.
- Keep existing runtime normalization to `small | medium | large`, defaulting invalid or missing values to `medium`.

## Verification
- `npx prisma generate`
- `npx tsc --noEmit`
- `npx eslint 'src/components/feed/PostImageGrid.tsx'` (0 errors, existing no-img warnings only)
- `git diff --check`
- `npm run build`
