### PR TITLE
Show Google sign-in option on LinkedIn OAuth login page

### DIFF
--- a/founder-sprint/src/actions/auth.ts
+++ b/founder-sprint/src/actions/auth.ts
@@ -11,6 +11,13 @@ export async function signInWithLinkedIn() {
     provider: "linkedin_oidc",
     options: {
       redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+      queryParams: {
+        // Force LinkedIn to render social login (Google/Apple/passkey) options
+        // even on platforms where they're hidden by default (iOS, in-app browsers).
+        // Officially documented by LinkedIn:
+        // https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow
+        enable_extended_login: "true",
+      },
     },
   });
 

--- a/founder-sprint/src/app/(auth)/auth/login/route.ts
+++ b/founder-sprint/src/app/(auth)/auth/login/route.ts
@@ -9,6 +9,13 @@ export async function GET(request: Request) {
     provider: "linkedin_oidc",
     options: {
       redirectTo: `${origin}/auth/callback`,
+      queryParams: {
+        // Force LinkedIn to render social login (Google/Apple/passkey) options
+        // even on platforms where they're hidden by default (iOS, in-app browsers).
+        // Officially documented by LinkedIn:
+        // https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow
+        enable_extended_login: "true",
+      },
     },
   });
 


### PR DESCRIPTION
## Problem

A specific invited user (`bibodid119@gmail.com`) could not log in to our app via LinkedIn. They use Google login on LinkedIn (their LinkedIn account was created via Google SSO, so it has no LinkedIn password), but on LinkedIn's login page during our OAuth flow they only saw the email + password form — no Google option. Trying email + password failed with "Wrong email or password" since no LinkedIn password exists for Google-SSO accounts.

Other users were not affected because they either set a LinkedIn password at some point or their browser autofills credentials they're not aware of.

## Root Cause

LinkedIn officially documents that social login buttons (Google / Apple / passkey) are **hidden by default** on certain platforms (iOS, in-app browsers, native webviews). They are only auto-rendered on desktop and Android web browsers.

To enable them on every platform, LinkedIn requires the `enable_extended_login=true` query parameter on the `/oauth/v2/authorization` request.

> "Social login (Google/Apple) and passkey login are currently supported on desktop and Android web browsers only. To enable these login options on other platforms (such as native apps), include the query parameter \`enable_extended_login=true\` while calling /oauth/v2/authorization."
> — [LinkedIn 3-Legged OAuth Flow docs](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow)

Our `signInWithOAuth` calls were not sending this parameter, so LinkedIn fell back to the minimal email + password form for everyone — even on desktop in some cases (LinkedIn's render conditions are inconsistent).

## Fix

Pass the `enable_extended_login=true` query parameter through Supabase's `signInWithOAuth` `queryParams` option in both call sites:

- `founder-sprint/src/app/(auth)/auth/login/route.ts` — GET route handler that initiates OAuth on the public login page
- `founder-sprint/src/actions/auth.ts` — server action `signInWithLinkedIn`

Supabase GoTrue forwards `queryParams` verbatim to LinkedIn's authorization URL, so this parameter reaches LinkedIn directly.

## Verification

Verified end-to-end with Playwright in incognito (no LinkedIn session, no Google session):

**Before** — empty container only, no visible Google button:
\`\`\`
Welcome Back
Email or Phone
Password
Cancel  Sign in
Forgot password?
\`\`\`

**After** — Google + Apple buttons rendered above the form:
\`\`\`
Sign in
[ G  Continue with Google ]
[    Sign in with Apple   ]
By clicking Continue, you agree to LinkedIn's...
─────── or ───────
Email or phone
Password
Forgot password?
Cancel  Sign in
\`\`\`

DOM inspection confirmed visible bounds for both buttons (Google: 304x42 at y=146, Apple: 304x42 at y=200) and the LinkedIn flow URL now contains \`\"enableExtendedLogin\":\"true\"\` plus a different tracking parameter (\`trk=oauth_3p_login\` instead of \`trk=oauth\`), confirming LinkedIn recognizes and honors the parameter.

## Edge Cases Considered

- **Same LinkedIn account, different auth method**: same OIDC token (same \`sub\`, same \`email\`) → no impact on existing users.
- **User has two separate LinkedIn accounts (one email/password, one Google SSO with different email)**: clicking Google button would log into the SSO account → email mismatch → \`/no-batch\`. Rare. Mitigated by the existing invite_token cookie fallback in the auth callback (within the cookie's 1-hour window). Not addressed in this PR; would benefit from extending the invite_token cookie maxAge to match the InvitationToken's 7-day expiry as a follow-up.
- **DB integrity**: the existing LinkedIn ID conflict detection in the auth callback prevents data corruption.

## Files Changed

- \`founder-sprint/src/actions/auth.ts\` — +7 lines
- \`founder-sprint/src/app/(auth)/auth/login/route.ts\` — +7 lines