### PR TITLE
Remove stale unstable_cache that hid admin role and invite changes

### DIFF
--- a/founder-sprint/src/actions/user-management.ts
+++ b/founder-sprint/src/actions/user-management.ts
@@ -5,7 +5,7 @@ import { getCurrentUser, isCurrentUserSuperAdmin, requireRole, isAdmin } from "@
 import { requireActiveBatch } from "@/lib/batch-gate";
 import { sendInvitationEmail } from "@/lib/email";
 import { ASSIGNABLE_ROLES, isRoleBelow } from "@/lib/role-hierarchy";
-import { revalidatePath, revalidateTag as revalidateTagBase, unstable_cache } from "next/cache";
+import { revalidatePath, revalidateTag as revalidateTagBase } from "next/cache";
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import type { ActionResult, UserRole } from "@/types";
@@ -1208,16 +1208,11 @@ export async function getBatchUsers(batchId: string) {
   if (!user) return [];
   if (!isAdmin(user) && user.batchId !== batchId) return [];
 
-  const batchUsers = await unstable_cache(
-    () =>
-      prisma.userBatch.findMany({
-        where: { batchId },
-        include: { user: true, batch: true },
-        orderBy: { invitedAt: "desc" },
-      }),
-    [`batch-users-${batchId}`],
-    { revalidate: 60, tags: [`batch-users-${batchId}`] }
-  )();
+  const batchUsers = await prisma.userBatch.findMany({
+    where: { batchId },
+    include: { user: true, batch: true },
+    orderBy: { invitedAt: "desc" },
+  });
 
   return batchUsers.map((membership) => ({
     ...membership,

--- a/founder-sprint/src/lib/permissions.ts
+++ b/founder-sprint/src/lib/permissions.ts
@@ -1,5 +1,4 @@
 import { cache } from "react";
-import { unstable_cache } from "next/cache";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { prisma } from "@/lib/prisma";
@@ -50,23 +49,17 @@ function hasAnyRole(subject: PermissionSubject, allowedRoles: UserRole[]): boole
 }
 
 const getCachedUserByEmail = (email: string, batchId?: string) =>
-  unstable_cache(
-    async () => {
-      return prisma.user.findUnique({
-        where: { email },
-        include: {
-          userBatches: {
-            where: batchId ? { batchId, status: "active" } : { status: "active" },
-            include: { batch: true },
-            take: 1,
-            orderBy: { batch: { createdAt: "desc" } },
-          },
-        },
-      });
+  prisma.user.findUnique({
+    where: { email },
+    include: {
+      userBatches: {
+        where: batchId ? { batchId, status: "active" } : { status: "active" },
+        include: { batch: true },
+        take: 1,
+        orderBy: { batch: { createdAt: "desc" } },
+      },
     },
-    [`current-user-${email}-${batchId || "default"}`],
-    { revalidate: 30, tags: ["current-user"] }
-  )();
+  });
 
 /**
  * Returns the authenticated user with their active batch context.


### PR DESCRIPTION
## Problem

Admin user management page (`/admin/users` filtered by batch) had two visible bugs:

1. **Role changes did not appear to apply** — clicking the role dropdown (Admin / Mentor / Founder / Co-founder) and the additional-role checkboxes saved correctly to the database, but the UI kept showing the old role. The same was true after a full page reload until ~60 seconds had passed.
2. **New invites did not appear in the user list** — successful invitations did not show up in the table until the cache TTL elapsed.

Both behaviors made it look like the mutations had silently failed.

## Root Cause

`getBatchUsers` and `getCachedUserByEmail` wrap their Prisma queries in the legacy `unstable_cache(...)` API and rely on tag-based invalidation:

```ts
unstable_cache(fn, [key], { revalidate: 60, tags: ["batch-users-..."] })
```

Server actions invalidate via a wrapper:

```ts
const revalidateTag = (tag: string) => revalidateTagBase(tag, "default");
```

In Next.js 16, the `revalidateTag(tag, profile)` second-argument variant targets the **new** `'use cache'` directive, **not** the legacy `unstable_cache` data cache. The two caches are different stores and tag invalidation does not cross between them. As a result:

- DB write succeeds.
- `revalidateTag("batch-users-...", "default")` is called, but it never invalidates the `unstable_cache` entry.
- The next call to `getBatchUsers` returns stale cached rows for up to 60 seconds.
- The UI re-fetch after the mutation reads the stale rows and rendered the old role / missing invitee.

## Evidence

A direct Prisma diagnostic on `slit.amazing@gmail.com` confirmed the DB-vs-UI mismatch and that writes work correctly:

```
DB:        UserBatch.role = "mentor"
UI badge:  "ADMIN"   ← stale cache
```

- Direct `prisma.userBatch.update` works immediately.
- Replaying the exact `updateUserRole` transaction logic works immediately.
- The only thing keeping the UI on the old value was the legacy cache.

## Fix

Remove the `unstable_cache` wrapping from both reads:

- `founder-sprint/src/actions/user-management.ts` — `getBatchUsers` (used by the admin user-management page when a batch filter is selected, and by the source-batch invite picker).
- `founder-sprint/src/lib/permissions.ts` — `getCachedUserByEmail` (used by `getCurrentUser` for every authenticated request to compute the caller's effective permissions).

The functions now query Prisma directly. `getCurrentUser` is still wrapped with React's per-request `cache()`, so we still dedupe within a single request — we just stop caching across requests. Existing `revalidateTag(...)` calls in the mutations become no-ops (they were already effectively no-ops, that was the bug); they are left in place to keep the diff minimal and avoid a separate cleanup pass.

## What This Solves

- Admin role changes (primary role and additional-role checkboxes) reflect immediately in the UI for everyone who can access the admin user management page.
- New invites show up in the table immediately after `inviteUser` / `bulkInviteUsers` / `inviteBatchMembersFromSource` succeed.
- The 30-second permission staleness for the currently-logged-in user (after their own role changes) is also gone.

## What This Does Not Solve

- Other unrelated bugs.
- The architectural-level wrapper `revalidateTag = (tag) => revalidateTagBase(tag, "default")` still exists in `user-management.ts` and `cache-helpers.ts`. If a future change reintroduces `unstable_cache` and uses this wrapper to invalidate it, the same bug would resurface. That is a separate, higher-risk cleanup and is intentionally out of scope here.

## Side Effects / Risk

| Concern | Assessment |
|---|---|
| Extra DB queries per request | `getCurrentUser` now hits Postgres on every authenticated render. The query is `findUnique` on `email` (indexed unique column). Sub-ms typical. For an internal admin tool with a small user base, the impact is imperceptible. |
| Extra DB queries on the admin page | `getBatchUsers` runs once per page load. ~35 rows joined with `users` and `batch` for a typical batch, with `@@index([batchId, status])` already in place. ~5–20 ms. |
| Concurrency / race conditions | None introduced. The cache was a read-side optimization; removing it does not affect transactional write semantics. |
| Security regression | None. The permission gate at the top of `getBatchUsers` (`isAdmin(user) && user.batchId !== batchId`) is preserved. |
| Dead `revalidateTag(...)` calls | Already no-ops before this change. Left in place to keep this PR focused. They cost nothing. |
| Type safety / API surface | No exported function signatures change. |

## How to Verify

1. Pull this branch and start the dev server.
2. Sign in as super_admin / admin.
3. Open `/admin/users`, filter by a batch.
4. Change a user's role via the dropdown — the badge updates immediately.
5. Toggle the "Also Mentor / Founder / Co-founder" checkboxes — additional roles update immediately.
6. Invite a new user — they appear in the list as soon as the action returns.