### PR TITLE
Add notificationEmail for separate notification routing from login email

### DIFF
--- a/founder-sprint/prisma/migrations/20260505140000_add_user_notification_email/migration.sql
+++ b/founder-sprint/prisma/migrations/20260505140000_add_user_notification_email/migration.sql
@@ -1,0 +1,6 @@
+-- Add an optional notification_email column on users so members can route
+-- transactional and event notifications to a different inbox than the one
+-- used for sign-in. Login flow (Supabase auth.users.email + User.email) is
+-- intentionally untouched. NULL means "fall back to email".
+
+ALTER TABLE "users" ADD COLUMN "notification_email" TEXT;

--- a/founder-sprint/prisma/schema.prisma
+++ b/founder-sprint/prisma/schema.prisma
@@ -75,9 +75,10 @@ enum EventType {
 
 // 1. User - Core user model
 model User {
-  id            String    @id @default(uuid()) @db.Uuid
-  email         String    @unique
-  name          String?
+  id                String    @id @default(uuid()) @db.Uuid
+  email             String    @unique
+  notificationEmail String?   @map("notification_email")
+  name              String?
   role          UserRole? @default(founder) @map("global_role")
   linkedinId    String?   @unique @map("linkedin_id")
   profileImage  String?   @map("profile_image")

--- a/founder-sprint/src/actions/assignment.ts
+++ b/founder-sprint/src/actions/assignment.ts
@@ -7,6 +7,7 @@ import { revalidatePath, revalidateTag as revalidateTagBase, unstable_cache } fr
 import { z } from "zod";
 import type { ActionResult } from "@/types";
 import { sendAssignmentPublishedEmail, sendAssignmentFeedbackEmail, sendAssignmentDeadlineReminderEmail, sendSubmissionCompletedEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 import { getUserCompanyIds } from "@/actions/company";
 
 const revalidateTag = (tag: string) => revalidateTagBase(tag, "default");
@@ -88,7 +89,7 @@ async function getAssignmentRecipientUsers(assignment: {
           some: { companyId: { in: assignment.targetCompanyIds }, isCurrent: true },
         },
       },
-      select: { id: true, email: true, name: true },
+      select: { id: true, email: true, notificationEmail: true, name: true },
     });
   }
 
@@ -103,7 +104,7 @@ async function getAssignmentRecipientUsers(assignment: {
         },
       },
     },
-    select: { id: true, email: true, name: true },
+    select: { id: true, email: true, notificationEmail: true, name: true },
   });
 }
 
@@ -301,7 +302,7 @@ export async function createAssignment(formData: FormData): Promise<ActionResult
     await Promise.all(
       recipients.map((recipient) =>
         sendAssignmentPublishedEmail({
-          to: recipient.email,
+          to: getRecipientEmail(recipient),
           recipientName: recipient.name,
           assignmentTitle: assignment.title,
           dueDate: assignment.dueDate,
@@ -539,6 +540,7 @@ export async function getAssignmentNonSubmitters(assignmentId: string) {
                   id: true,
                   name: true,
                   email: true,
+                  notificationEmail: true,
                   profileImage: true,
                   companyMemberships: {
                     where: { isCurrent: true },
@@ -608,7 +610,7 @@ export async function sendAssignmentDeadlineReminders(assignmentId: string): Pro
   await Promise.all(
     recipients.map((recipient) =>
       sendAssignmentDeadlineReminderEmail({
-        to: recipient.email,
+        to: getRecipientEmail(recipient),
         recipientName: recipient.name,
         assignmentTitle: assignment.title,
         dueDate: assignment.dueDate,
@@ -780,7 +782,7 @@ export async function submitAssignment(
     },
     select: {
       userId: true,
-      user: { select: { email: true, name: true } },
+      user: { select: { email: true, notificationEmail: true, name: true } },
     },
   });
 
@@ -800,7 +802,7 @@ export async function submitAssignment(
     await Promise.all(
       adminRecipients.map((recipient) =>
         sendSubmissionCompletedEmail({
-          to: recipient.user.email,
+          to: getRecipientEmail(recipient.user),
           founderName: user.name || user.email,
           assignmentTitle: assignment.title,
           submissionUrl,
@@ -1028,6 +1030,7 @@ export async function addFeedback(
       author: {
         select: {
           email: true,
+          notificationEmail: true,
           name: true,
         },
       },
@@ -1051,7 +1054,7 @@ export async function addFeedback(
       const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
       const submissionUrl = `${appUrl}/submissions/${submissionId}`;
       await sendAssignmentFeedbackEmail({
-        to: submission.author.email,
+        to: getRecipientEmail(submission.author),
         recipientName: submission.author.name,
         assignmentTitle: submission.assignment.title,
         feedbackContent: content.trim(),

--- a/founder-sprint/src/actions/feed.ts
+++ b/founder-sprint/src/actions/feed.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@prisma/client";
 import { createClient } from "@supabase/supabase-js";
 import { getCurrentUser, isAdmin } from "@/lib/permissions";
 import { sendFeedMentionEmail, sendFeedReplyNotificationEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 import { revalidatePath, revalidateTag as revalidateTagBase, unstable_cache } from "next/cache";
 import { z } from "zod";
 import type { ActionResult } from "@/types";
@@ -284,7 +285,7 @@ export async function createPost(formData: FormData): Promise<ActionResult<{ id:
     if (uniqueMentionedUserIds.length > 0) {
       const mentionedUsers = await prisma.user.findMany({
         where: { id: { in: uniqueMentionedUserIds } },
-        select: { id: true, email: true, name: true },
+        select: { id: true, email: true, notificationEmail: true, name: true },
       });
 
       if (mentionedUsers.length > 0) {
@@ -308,7 +309,7 @@ export async function createPost(formData: FormData): Promise<ActionResult<{ id:
         await Promise.all(
           mentionedUsers.map((mentionedUser) =>
             sendFeedMentionEmail({
-              to: mentionedUser.email,
+              to: getRecipientEmail(mentionedUser),
               recipientName: mentionedUser.name,
               authorName: user.name || user.email,
               postExcerpt,
@@ -600,6 +601,7 @@ export async function createComment(
           select: {
             id: true,
             email: true,
+            notificationEmail: true,
             name: true,
           },
         },
@@ -633,7 +635,7 @@ export async function createComment(
 
     const postUrl = `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/feed/${postId}`;
     const emailResult = await sendFeedReplyNotificationEmail({
-      to: parentCommentData.author.email,
+      to: getRecipientEmail(parentCommentData.author),
       recipientName: parentCommentData.author.name,
       replierName: user.name || user.email,
       replyContent: content.trim().slice(0, 220),

--- a/founder-sprint/src/actions/office-hour.ts
+++ b/founder-sprint/src/actions/office-hour.ts
@@ -9,6 +9,7 @@ import { isCalendarConfigured, createCalendarEventWithMeet } from "@/lib/google-
 import { fromZonedTime } from "date-fns-tz";
 import { startOfWeek } from "date-fns";
 import { sendOfficeHourRequestEmail, sendOfficeHourBookingConfirmEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 import { revalidateSchedule } from "@/lib/cache-helpers";
 import type { UserWithBatch } from "@/types";
 import type { CompanyOption, FounderOption, MentorOption } from "@/types/invite";
@@ -637,7 +638,7 @@ export async function proposeOfficeHour(formData: FormData): Promise<ActionResul
       return { success: false, error: "Cannot request office hours in the past" };
     }
 
-    let targetHost: { id: string; email: string; name: string | null } | null = null;
+    let targetHost: { id: string; email: string; notificationEmail: string | null; name: string | null } | null = null;
 
     if (mentorId) {
       const mentorMembership = await prisma.userBatch.findFirst({
@@ -656,6 +657,7 @@ export async function proposeOfficeHour(formData: FormData): Promise<ActionResul
             select: {
               id: true,
               email: true,
+              notificationEmail: true,
               name: true,
             },
           },
@@ -675,6 +677,7 @@ export async function proposeOfficeHour(formData: FormData): Promise<ActionResul
         select: {
           id: true,
           email: true,
+          notificationEmail: true,
           name: true,
         },
       });
@@ -722,7 +725,7 @@ export async function proposeOfficeHour(formData: FormData): Promise<ActionResul
         select: { name: true },
       });
       sendOfficeHourRequestEmail({
-        to: targetHost.email,
+        to: getRecipientEmail(targetHost),
         hostName: targetHost.name || targetHost.email,
         requesterName: user.name || user.email,
         companyName: company?.name,
@@ -1077,14 +1080,14 @@ export async function requestOfficeHour(slotId: string, companyId: string, messa
       const slotWithHost = await prisma.officeHourSlot.findUnique({
         where: { id: validated.slotId },
         include: {
-          host: { select: { email: true, name: true } },
+          host: { select: { email: true, notificationEmail: true, name: true } },
           company: { select: { name: true } },
           // group relation removed — office hours use company now
         },
       });
       if (slotWithHost?.host) {
         sendOfficeHourRequestEmail({
-          to: slotWithHost.host.email,
+          to: getRecipientEmail(slotWithHost.host),
           hostName: slotWithHost.host.name || slotWithHost.host.email,
           requesterName: user.name || user.email,
           companyName: slotWithHost.company?.name,

--- a/founder-sprint/src/actions/profile.ts
+++ b/founder-sprint/src/actions/profile.ts
@@ -17,6 +17,17 @@ const UpdateProfileSchema = z.object({
   jobTitle: z.string().max(100, "Job title must be 100 characters or less").optional(),
   company: z.string().max(100, "Company must be 100 characters or less").optional(),
   bio: z.string().max(500, "Bio must be 500 characters or less").optional(),
+  notificationEmail: z
+    .string()
+    .email("Notification email must be a valid email address")
+    .max(254, "Notification email is too long")
+    .optional()
+    .nullable()
+    .transform((value) => {
+      if (value === null || value === undefined) return null;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+    }),
   profileImage: z.string().optional().nullable(),
   headline: z.string().max(200, "Headline must be 200 characters or less").optional(),
   location: z.string().max(200, "Location must be 200 characters or less").optional(),
@@ -449,6 +460,7 @@ export async function updateExtendedProfile(formData: FormData): Promise<ActionR
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
+  const rawNotificationEmail = optionalString(formData.get("notificationEmail"));
   const raw = {
     name: formData.get("name") as string,
     jobTitle: optionalString(formData.get("jobTitle")),
@@ -461,6 +473,7 @@ export async function updateExtendedProfile(formData: FormData): Promise<ActionR
     twitterUrl: optionalString(formData.get("twitterUrl")),
     websiteUrl: optionalString(formData.get("websiteUrl")),
     timezone: optionalString(formData.get("timezone")),
+    notificationEmail: rawNotificationEmail && rawNotificationEmail.length > 0 ? rawNotificationEmail : null,
   };
 
   const parsed = UpdateProfileSchema.safeParse(raw);
@@ -485,6 +498,7 @@ export async function updateExtendedProfile(formData: FormData): Promise<ActionR
       twitterUrl: parsed.data.twitterUrl || null,
       websiteUrl: parsed.data.websiteUrl || null,
       timezone: parsed.data.timezone ? toIanaTimezone(parsed.data.timezone) : null,
+      notificationEmail: parsed.data.notificationEmail ?? null,
     },
   });
 

--- a/founder-sprint/src/actions/profile.ts
+++ b/founder-sprint/src/actions/profile.ts
@@ -460,7 +460,7 @@ export async function updateExtendedProfile(formData: FormData): Promise<ActionR
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
-  const rawNotificationEmail = optionalString(formData.get("notificationEmail"));
+  const trimmedNotificationEmail = optionalString(formData.get("notificationEmail"))?.trim();
   const raw = {
     name: formData.get("name") as string,
     jobTitle: optionalString(formData.get("jobTitle")),
@@ -473,7 +473,7 @@ export async function updateExtendedProfile(formData: FormData): Promise<ActionR
     twitterUrl: optionalString(formData.get("twitterUrl")),
     websiteUrl: optionalString(formData.get("websiteUrl")),
     timezone: optionalString(formData.get("timezone")),
-    notificationEmail: rawNotificationEmail && rawNotificationEmail.length > 0 ? rawNotificationEmail : null,
+    notificationEmail: trimmedNotificationEmail && trimmedNotificationEmail.length > 0 ? trimmedNotificationEmail : null,
   };
 
   const parsed = UpdateProfileSchema.safeParse(raw);

--- a/founder-sprint/src/actions/user-management.ts
+++ b/founder-sprint/src/actions/user-management.ts
@@ -63,6 +63,7 @@ const USER_ADMIN_AUDIT_ACTIONS = [
   "user_batch_dropped_out",
   "user_batch_restored",
   "invite_resent",
+  "user_notification_email_changed",
 ] as const;
 
 async function createAuditLogEntry(params: {
@@ -724,6 +725,68 @@ export async function updateAdditionalRoles(
 
   revalidatePath("/admin/users");
   revalidateTag(`batch-users-${batchId}`);
+  revalidateTag("current-user");
+  return { success: true, data: undefined };
+}
+
+const NotificationEmailInputSchema = z
+  .string()
+  .email("Notification email must be a valid email address")
+  .max(254, "Notification email is too long")
+  .optional()
+  .nullable()
+  .transform((value) => {
+    if (value === null || value === undefined) return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+  });
+
+export async function updateUserNotificationEmail(
+  userId: string,
+  notificationEmailInput: string | null
+): Promise<ActionResult> {
+  const actor = await getCurrentUser();
+  if (!actor) return { success: false, error: "Not authenticated" };
+
+  try {
+    requireRole(actor.role, ["super_admin", "admin"]);
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const parsed = NotificationEmailInputSchema.safeParse(notificationEmailInput);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0]?.message || "Invalid email" };
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, notificationEmail: true },
+  });
+  if (!target) return { success: false, error: "User not found" };
+
+  const nextValue = parsed.data;
+  if (nextValue === target.notificationEmail) {
+    return { success: true, data: undefined };
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { notificationEmail: nextValue },
+  });
+
+  await createAuditLogEntry({
+    actor,
+    action: "user_notification_email_changed",
+    targetId: userId,
+    details: {
+      userEmail: target.email,
+      previousNotificationEmail: target.notificationEmail,
+      newNotificationEmail: nextValue,
+    },
+  });
+
+  revalidatePath("/admin/users");
   revalidateTag("current-user");
   return { success: true, data: undefined };
 }

--- a/founder-sprint/src/app/(auth)/auth/callback/route.ts
+++ b/founder-sprint/src/app/(auth)/auth/callback/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { classifyAvatarSource } from "@/lib/avatar-source";
 import { ingestLinkedInAvatar } from "@/lib/linkedin-avatar-ingest";
 import { sendBatchOnboardingDigestEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { revalidateTag as revalidateTagBase } from "next/cache";
@@ -286,7 +287,7 @@ export async function GET(request: Request) {
           const appUrl = process.env.NEXT_PUBLIC_APP_URL || origin;
           const linkBase = `${appUrl}/api/batch/select?batchId=${batchForDigest.id}&next=`;
           const emailResult = await sendBatchOnboardingDigestEmail({
-            to: user.email,
+            to: getRecipientEmail(user),
             recipientName: user.name,
             batchName: batchForDigest.name,
             assignmentsUrl: `${linkBase}${encodeURIComponent("/assignments")}`,

--- a/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
@@ -11,6 +11,7 @@ import {
   inviteBatchMembersFromSource,
   updateUserRole,
   updateAdditionalRoles,
+  updateUserNotificationEmail,
   removeUserFromBatch,
   cancelInvite,
   resendInvite,
@@ -64,6 +65,7 @@ interface BatchUser {
   user: {
     id: string;
     email: string;
+    notificationEmail: string | null;
     name: string | null;
     profileImage: string | null;
     status: "active" | "inactive" | string;
@@ -165,6 +167,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
   const [inviteLink, setInviteLink] = useState<string | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState<{ userId: string; userName: string; batchId: string; batchName: string } | null>(null);
+  const [editNotifEmail, setEditNotifEmail] = useState<{ userId: string; userName: string; loginEmail: string; currentValue: string } | null>(null);
+  const [notifEmailDraft, setNotifEmailDraft] = useState("");
+  const [notifEmailError, setNotifEmailError] = useState("");
   const [companies, setCompanies] = useState<Array<{ id: string; name: string; _count: { members: number } }>>([]);
   const [selectedRole, setSelectedRole] = useState("founder");
   const [inviteMode, setInviteMode] = useState<"single" | "bulk">("single");
@@ -604,6 +609,44 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     });
   };
 
+  const openEditNotifEmail = (userBatch: BatchUser) => {
+    const current = userBatch.user.notificationEmail || "";
+    setEditNotifEmail({
+      userId: userBatch.user.id,
+      userName: getDisplayName(userBatch.user),
+      loginEmail: userBatch.user.email,
+      currentValue: current,
+    });
+    setNotifEmailDraft(current);
+    setNotifEmailError("");
+  };
+
+  const handleSaveNotifEmail = () => {
+    if (!editNotifEmail) return;
+    const trimmed = notifEmailDraft.trim();
+    if (trimmed.length > 0) {
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailPattern.test(trimmed)) {
+        setNotifEmailError("Enter a valid email address");
+        return;
+      }
+    }
+    setNotifEmailError("");
+    startTransition(async () => {
+      const result = await updateUserNotificationEmail(
+        editNotifEmail.userId,
+        trimmed.length > 0 ? trimmed : null
+      );
+      if (result.success) {
+        toast.success(trimmed.length > 0 ? "Notification email updated" : "Notification email cleared");
+        setEditNotifEmail(null);
+        refreshCurrentScope();
+      } else {
+        setNotifEmailError(result.error);
+      }
+    });
+  };
+
   const getAuditDescription = (entry: AuditEntry) => {
     let details: Record<string, unknown> = {};
     try {
@@ -642,6 +685,12 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
     if (entry.action === "invite_resent") {
       return `${entry.userName} resent an invite to ${userEmail}`;
+    }
+
+    if (entry.action === "user_notification_email_changed") {
+      const next = typeof details.newNotificationEmail === "string" ? details.newNotificationEmail : null;
+      const verb = next ? `set notification email to ${next}` : "cleared notification email";
+      return `${entry.userName} ${verb} for ${userEmail}`;
     }
 
     return `${entry.userName} performed ${entry.action}`;
@@ -776,6 +825,14 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
               disabled={isPending}
             >
               Remove
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => openEditNotifEmail(userBatch)}
+              disabled={isPending}
+            >
+              Notif Email
             </Button>
           </div>
         )}
@@ -1491,6 +1548,58 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
             </Button>
           </div>
         </div>
+      </Modal>
+
+      {/* Notification Email Modal */}
+      <Modal
+        open={!!editNotifEmail}
+        onClose={() => {
+          setEditNotifEmail(null);
+          setNotifEmailError("");
+        }}
+        title="Edit Notification Email"
+      >
+        {editNotifEmail && (
+          <div className="space-y-4">
+            <p style={{ color: "var(--color-foreground-secondary)", fontSize: 14 }}>
+              <strong>{editNotifEmail.userName}</strong> ({editNotifEmail.loginEmail})
+            </p>
+            <Input
+              label="Notification Email"
+              type="email"
+              value={notifEmailDraft}
+              onChange={(e) => setNotifEmailDraft(e.target.value)}
+              maxLength={254}
+              placeholder="leave empty to use login email"
+            />
+            <p style={{ fontSize: 12, color: "var(--color-foreground-secondary)" }}>
+              비워두면 로그인 이메일({editNotifEmail.loginEmail})로 알림이 전송됩니다.
+            </p>
+            {notifEmailError && (
+              <div className="form-error p-3 rounded-lg text-sm">
+                {notifEmailError}
+              </div>
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setEditNotifEmail(null);
+                  setNotifEmailError("");
+                }}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSaveNotifEmail}
+                loading={isPending}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
       </Modal>
     </div>
   );

--- a/founder-sprint/src/app/(dashboard)/settings/ProfileForm.tsx
+++ b/founder-sprint/src/app/(dashboard)/settings/ProfileForm.tsx
@@ -14,6 +14,7 @@ interface ProfileFormProps {
   initialData: {
     name: string | null;
     email: string;
+    notificationEmail: string;
     jobTitle: string;
     company: string;
     bio: string;
@@ -27,7 +28,7 @@ interface ProfileFormProps {
   };
 }
 
-type SectionKey = "identity" | "work" | "bio" | "location" | "profileImage";
+type SectionKey = "identity" | "work" | "bio" | "location" | "profileImage" | "notifications";
 
 function ProfileImageUpload({
   currentImage,
@@ -167,6 +168,7 @@ export function ProfileForm({ initialData }: ProfileFormProps) {
     websiteUrl: initialData.websiteUrl,
     timezone: initialData.timezone,
     profileImage: initialData.profileImage,
+    notificationEmail: initialData.notificationEmail,
   });
 
   const [bioCharCount, setBioCharCount] = useState(initialData.bio.length);
@@ -212,6 +214,11 @@ export function ProfileForm({ initialData }: ProfileFormProps) {
         websiteUrl: initialData.websiteUrl,
       }));
       setLocationCharCount(initialData.location.length);
+    } else if (section === "notifications") {
+      setFields((prev) => ({
+        ...prev,
+        notificationEmail: initialData.notificationEmail,
+      }));
     }
     setEditingSection(null);
   };
@@ -231,6 +238,7 @@ export function ProfileForm({ initialData }: ProfileFormProps) {
     formData.append("twitterUrl", fields.twitterUrl);
     formData.append("websiteUrl", fields.websiteUrl);
     formData.append("timezone", fields.timezone);
+    formData.append("notificationEmail", fields.notificationEmail || "");
 
     startTransition(async () => {
       const result = await updateExtendedProfile(formData);
@@ -276,8 +284,76 @@ export function ProfileForm({ initialData }: ProfileFormProps) {
           borderRadius: "4px",
         }}
       >
-        <span style={{ fontSize: 14, fontWeight: 500, color: "#666666", minWidth: 120 }}>Email:</span>
+        <span style={{ fontSize: 14, fontWeight: 500, color: "#666666", minWidth: 120 }}>Login Email:</span>
         <span style={{ fontSize: 14, color: "#2F2C26" }}>{initialData.email}</span>
+      </div>
+
+      <div
+        style={{
+          borderBottom: "1px solid #e0e0e0",
+          paddingBottom: 20,
+          marginBottom: 20,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
+          <h3 style={{ fontSize: 16, fontWeight: 600, color: "#2F2C26", margin: 0 }}>Notifications</h3>
+          {editingSection !== "notifications" ? (
+            <button
+              type="button"
+              onClick={() => handleEdit("notifications")}
+              style={{
+                background: "none",
+                border: "none",
+                color: "#1A1A1A",
+                cursor: "pointer",
+                fontSize: 14,
+                fontWeight: 500,
+                padding: "4px 8px",
+              }}
+            >
+              Edit
+            </button>
+          ) : (
+            <div style={{ display: "flex", gap: 8 }}>
+              <Button variant="ghost" size="sm" onClick={() => handleCancel("notifications")} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleSave} loading={isPending} disabled={isPending}>
+                Save
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {editingSection === "notifications" ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <Input
+              label="Notification Email"
+              type="email"
+              value={fields.notificationEmail}
+              onChange={(e) => updateField("notificationEmail", e.target.value)}
+              maxLength={254}
+              placeholder="optional@example.com"
+            />
+            <p style={{ fontSize: 12, color: "#999999" }}>
+              비워두면 가입 이메일({initialData.email})로 알림이 전송됩니다.
+            </p>
+          </div>
+        ) : (
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <span style={{ fontSize: 14, fontWeight: 500, color: "#666666", minWidth: 120 }}>Notification Email:</span>
+            <span style={{ fontSize: 14, color: initialData.notificationEmail ? "#2F2C26" : "#999999" }}>
+              {initialData.notificationEmail || `Using login email (${initialData.email})`}
+            </span>
+          </div>
+        )}
       </div>
 
       <div

--- a/founder-sprint/src/app/(dashboard)/settings/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/settings/page.tsx
@@ -73,6 +73,7 @@ export default async function SettingsPage({
               initialData={{
                 name: user.name || "",
                 email: user.email,
+                notificationEmail: user.notificationEmail || "",
                 jobTitle: user.jobTitle || "",
                 company: profile?.companyMemberships?.find(m => m.isCurrent)?.company.name || user.company || "",
                 bio: user.bio || "",

--- a/founder-sprint/src/app/api/cron/deadline-reminders/route.ts
+++ b/founder-sprint/src/app/api/cron/deadline-reminders/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendAssignmentDeadlineReminderEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
@@ -76,6 +77,7 @@ export async function GET(request: NextRequest) {
                   id: true,
                   name: true,
                   email: true,
+                  notificationEmail: true,
                   companyMemberships: {
                     where: { isCurrent: true },
                     select: { companyId: true },
@@ -112,7 +114,7 @@ export async function GET(request: NextRequest) {
       .map((userBatch) => userBatch.user);
 
     const finalRecipients = overrideEmail
-      ? recipients.map((recipient) => ({ ...recipient, email: overrideEmail }))
+      ? recipients.map((recipient) => ({ ...recipient, email: overrideEmail, notificationEmail: null }))
       : recipients;
 
     const existingNotifications = finalRecipients.length > 0 && !overrideEmail
@@ -135,7 +137,7 @@ export async function GET(request: NextRequest) {
       const sendResults = await Promise.all(
         unsentRecipients.map((recipient) =>
           sendAssignmentDeadlineReminderEmail({
-            to: recipient.email,
+            to: getRecipientEmail(recipient),
             recipientName: recipient.name,
             assignmentTitle: assignment.title,
             dueDate: assignment.dueDate,

--- a/founder-sprint/src/lib/email-routing.ts
+++ b/founder-sprint/src/lib/email-routing.ts
@@ -1,0 +1,8 @@
+type RecipientLike = {
+  email: string;
+  notificationEmail?: string | null;
+};
+
+export function getRecipientEmail(user: RecipientLike): string {
+  return user.notificationEmail?.trim() || user.email;
+}

--- a/founder-sprint/src/lib/permissions.ts
+++ b/founder-sprint/src/lib/permissions.ts
@@ -166,6 +166,7 @@ export const getCurrentUser = cache(async (batchId?: string): Promise<UserWithBa
       return {
         id: user.id,
         email: user.email,
+        notificationEmail: (user as { notificationEmail?: string | null }).notificationEmail ?? null,
         name: user.name,
         profileImage: user.profileImage,
         timezone: userTimezone,
@@ -191,6 +192,7 @@ export const getCurrentUser = cache(async (batchId?: string): Promise<UserWithBa
   return {
     id: user.id,
     email: user.email,
+    notificationEmail: (user as { notificationEmail?: string | null }).notificationEmail ?? null,
     name: user.name,
     profileImage: user.profileImage,
     timezone: userTimezone,

--- a/founder-sprint/src/types/index.ts
+++ b/founder-sprint/src/types/index.ts
@@ -18,6 +18,7 @@ export type StaffRole = Extract<UserRole, "super_admin" | "admin" | "mentor">;
 export interface UserWithBatch {
   id: string;
   email: string;
+  notificationEmail: string | null;
   name: string | null;
   profileImage: string | null;
   timezone: string | null;


### PR DESCRIPTION
## Goal

Decouple notification destination from login identity. Add an optional `User.notificationEmail` column. When set, every transactional notification (office hours, assignments, mentions, feed replies, batch onboarding digest, deadline reminders) ships to that address instead of `User.email`. When NULL — current behavior, untouched.

**Login identity (`User.email` and Supabase `auth.users.email`) is not touched. No auth, OAuth, RLS, or session behavior changes.**

## Why

A real user (invited at one address but wants notifications at another) needed this. Repeatedly seen pattern in similar admin tools. Cleaner separation of concerns than trying to migrate auth email out from under OAuth.

## What ships

### Schema + Migration
- `prisma/schema.prisma` — new `notificationEmail String? @map(\"notification_email\")` on `User`.
- `prisma/migrations/20260505140000_add_user_notification_email/migration.sql` — additive nullable column. No backfill, no constraint changes.

### Helper
- `src/lib/email-routing.ts` — `getRecipientEmail({ email, notificationEmail }) => email`. Trims `notificationEmail`; falls back to `email` if null/empty/whitespace. Pure function.

### All notification senders updated to use the helper

Every transactional notification path now resolves the recipient via `getRecipientEmail`:

| File | Sender | Where |
|---|---|---|
| `src/app/(auth)/auth/callback/route.ts` | `sendBatchOnboardingDigestEmail` | onboarding digest |
| `src/actions/office-hour.ts` (×2) | `sendOfficeHourRequestEmail` | host notification |
| `src/actions/assignment.ts` (×4) | `sendAssignmentPublishedEmail`, `sendAssignmentDeadlineReminderEmail`, `sendSubmissionCompletedEmail`, `sendAssignmentFeedbackEmail` | founder/mentor notifications |
| `src/app/api/cron/deadline-reminders/route.ts` | `sendAssignmentDeadlineReminderEmail` | nightly cron |
| `src/actions/feed.ts` (×2) | `sendFeedMentionEmail`, `sendFeedReplyNotificationEmail` | mention + reply |

`sendInvitationEmail` is intentionally NOT touched — invitations go to the form-input email at a time when the User row may not exist yet, and routing through `notificationEmail` would be meaningless there.

For each call site, the upstream Prisma query was extended to also `select: { notificationEmail: true }` so the helper has the field available.

### User self-edit UI (Settings page)

- `src/app/(dashboard)/settings/ProfileForm.tsx` — new editable \"Notifications\" section above Identity. Shows current state, lets user set/clear notification email. Falls back to login email when blank, with explicit help text.
- `src/app/(dashboard)/settings/page.tsx` — passes `notificationEmail` from current user to the form.
- `src/actions/profile.ts` — `updateExtendedProfile` schema now includes `notificationEmail` (zod email + trim + lowercase + null when empty). Whitelisted in the Prisma update payload.
- Existing \"Email\" label changed to \"Login Email\" for clarity.

### Admin override UI (admin/users panel)

- `src/app/(dashboard)/admin/users/UserManagement.tsx` — \"Notif Email\" button on each user row opens a modal. Admin can set or clear another user's notification email.
- `src/actions/user-management.ts` — new server action `updateUserNotificationEmail(userId, value)`. Requires admin/super_admin. Same zod validation. Writes audit log entry `user_notification_email_changed` (added to the `USER_ADMIN_AUDIT_ACTIONS` literal). No-op on identical value (no audit noise).
- Admin audit feed (`getAuditDescription`) now renders human-readable text for the new action.

### Type pass-through

- `src/types/index.ts` — `UserWithBatch` now includes `notificationEmail: string | null`.
- `src/lib/permissions.ts` — `getCurrentUser` propagates `notificationEmail` from `User` row through both elevated-admin and regular paths.

## Cron override safety

`src/app/api/cron/deadline-reminders/route.ts` has a dev-only `?overrideEmail=...` query param for manual cron testing. The override now also nulls out `notificationEmail`, so the helper actually uses the override instead of resolving back to a real user's notification address.

## Risk analysis

| Risk | Mitigation |
|---|---|
| Sender call site missed → that path uses login email | helper falls back to `email` cleanly; no regression vs current behavior |
| `notificationEmail` not selected in Prisma query → helper falls back | identical fallback; harmless |
| Invalid email submitted | zod rejects, user sees error |
| Auth / RLS impact | none — `User.email` and `auth.users.email` never touched |
| Existing users with NULL `notificationEmail` | unchanged behavior — fallback to `email` |
| Audit log noise on no-op admin saves | server action short-circuits when value identical |

Aggregate risk: **LOW**. Migration is additive nullable column.

## Verification

### Static
- LSP diagnostics clean on every modified file (verified after `prisma generate` so the new `notificationEmail` field is known to the Prisma client type).
- Helper function compiles cleanly in isolation.
- Grep audit: only one remaining `to: \w+\.email` pattern in `src/`, in `sendInvitationEmail` which is intentional.
- `getRecipientEmail` is invoked in 10 production notification paths (all the senders enumerated above) plus the import in 5 files = 15 lines.

### Dynamic (intentionally bounded)
The plan called for one bounded test on `slit.amazing@gmail.com` only. Skipped in favor of static verification because every sender path that triggers from the dev account would notify other users (assignment publish, mentions, etc.), which would violate the \"do not touch any other account\" constraint. The change is fail-safe: any miss falls back to existing email behavior, so worst case is the new feature being inert for that path, never a regression. Admin can sanity-check one path post-merge in a controlled way.

### Regression
Existing users with `notificationEmail = NULL` keep receiving notifications at `User.email` — verified by inspection of `getRecipientEmail`'s null-coalescing.

## Migration / Deploy steps

1. Merge this PR.
2. Run `npx prisma migrate deploy` (or equivalent) on each environment to apply `add_user_notification_email`.
3. Restart app so the regenerated Prisma client + new code path are live.
4. (Optional, for the trigger user) Set `notification_email` for individual users via the new admin UI or directly in DB:
   ```sql
   UPDATE users SET notification_email = 'yugyeong1203@gmail.com' WHERE email = 'yureka.publish@gmail.com';
   ```

## Out of scope

- Renaming `User.email` to `User.loginEmail` (50+ file blast radius).
- Email verification flow on `notificationEmail` (this is a self-routing decision; if user typos, they fix it).
- Touching invitation flow (`sendInvitationEmail`).
- Per-event-type notification preferences (orthogonal feature).
- Public profile display of `notificationEmail` (private routing info, intentionally not exposed).

## Plan + review trail

Plan saved at `.sisyphus/plans/notification-email.md`. Reviewed by Momus plan critic before implementation; verdict was [OKAY].