### PR TITLE
Show notificationEmail on public profile contact when set

### DIFF
--- a/founder-sprint/src/actions/profile.ts
+++ b/founder-sprint/src/actions/profile.ts
@@ -245,6 +245,7 @@ export async function getUserProfile(userId: string): Promise<ActionResult<{
 export async function getEnhancedUserProfile(userId: string): Promise<ActionResult<{
   id: string;
   email: string;
+  notificationEmail: string | null;
   name: string | null;
   profileImage: string | null;
   jobTitle: string | null;
@@ -316,6 +317,7 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
     select: {
       id: true,
       email: true,
+      notificationEmail: true,
       name: true,
       profileImage: true,
       jobTitle: true,
@@ -394,6 +396,7 @@ export async function getEnhancedUserProfile(userId: string): Promise<ActionResu
     data: {
       id: profile.id,
       email: profile.email,
+      notificationEmail: profile.notificationEmail,
       name: profile.name,
       profileImage: profile.profileImage,
       jobTitle: profile.jobTitle,

--- a/founder-sprint/src/app/(dashboard)/profile/[userId]/ProfileClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/profile/[userId]/ProfileClient.tsx
@@ -41,6 +41,7 @@ interface Batch {
 interface Profile {
   id: string;
   email: string;
+  notificationEmail: string | null;
   name: string | null;
   profileImage: string | null;
   jobTitle: string | null;
@@ -851,7 +852,7 @@ export function ProfileClient({
                   Contact
                 </h3>
                 <a
-                  href={`mailto:${profile.email}`}
+                  href={`mailto:${profile.notificationEmail || profile.email}`}
                   style={{
                     fontSize: "14px",
                     color: "#1A1A1A",
@@ -859,7 +860,7 @@ export function ProfileClient({
                     wordBreak: "break-all",
                   }}
                 >
-                  {profile.email}
+                  {profile.notificationEmail || profile.email}
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Problem

After PR #94, users can set a personal `notificationEmail` for routing notifications to a different inbox than their login email. The Settings UI and admin panel use it correctly, and every server-side notification sender routes through `getRecipientEmail` to honor it.

But the **public profile page** (`/profile/[userId]`) — visible to other batch members in the directory — still shows `User.email` (login email) in its CONTACT card. So someone visiting another member's profile sees the login email and `mailto:`s that, even when the member explicitly set a different contact preference.

## Fix

In `getEnhancedUserProfile`:
- Add `notificationEmail` to the Prisma `select`.
- Add `notificationEmail: string | null` to the return type.
- Return `profile.notificationEmail` in the data payload.

In `ProfileClient.tsx`:
- Add `notificationEmail: string | null` to the `Profile` interface.
- In the CONTACT card, show `profile.notificationEmail || profile.email`. Same fallback for the `mailto:` href.

When `notificationEmail` is unset (NULL) — the default for everyone before they touch it — the existing login-email behavior is preserved exactly.

## Why this matches the broader semantic

`notificationEmail` is the user's "preferred contact email" — `User.email` is just the address tied to their auth identity. Anywhere a human-facing contact email is shown to other people, `notificationEmail` should win when set. PR #94 did this for the system's own outgoing emails; this PR extends the same semantic to the profile UI surface.

## Risk

Tiny.
- Profile page already loads via `getEnhancedUserProfile` — just one extra column in the select.
- Display logic uses simple `||` fallback; users who haven't set `notificationEmail` see exactly the same email as before.
- No schema change, no migration.

## Verification

- LSP diagnostics clean on touched files.
- Manual: a member's profile shows their `notificationEmail` in CONTACT after they set one, and the `mailto:` link opens to that address. Members without `notificationEmail` set see their login email as before.

## Out of scope

- Admin/users table doesn't currently surface `notificationEmail` next to `email` either; could add as a follow-up if useful but not requested. (Admin panel still has the per-row "Notif Email" edit button from PR #94.)