### PR TITLE
Show parent nav category (Community/Batch) above landing page headings; fix Groups heading typo

### DIFF
--- a/founder-sprint/src/app/(dashboard)/assignments/AssignmentsList.tsx
+++ b/founder-sprint/src/app/(dashboard)/assignments/AssignmentsList.tsx
@@ -11,6 +11,7 @@ import { Modal } from "@/components/ui/Modal";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Badge } from "@/components/ui/Badge";
 import { CompanySelect, type CompanyOption } from "@/components/ui/CompanySelect";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { formatDate } from "@/lib/utils";
 import { useToast } from "@/hooks/useToast";
 
@@ -143,9 +144,12 @@ export function AssignmentsList({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-4">
-        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>
-          Assignments
-        </h1>
+        <div>
+          <PageCategoryLabel label="Batch" />
+          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>
+            Assignments
+          </h1>
+        </div>
         {canCreate && <Button onClick={() => setCreateOpen(true)}>Create Assignment</Button>}
       </div>
 

--- a/founder-sprint/src/app/(dashboard)/companies/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/companies/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { getCurrentUser, isAdmin, isFounder } from "@/lib/permissions";
 import { getCompaniesDirectory } from "@/actions/directory";
 import { getMyCompanyRequestContext } from "@/actions/company";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { NewCompanyRequestButton } from "./NewCompanyRequestButton";
 import { SearchBar } from "./SearchBar";
 
@@ -95,6 +96,7 @@ export default async function CompaniesPage({
     <div>
       <div style={{ marginBottom: "32px", display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "16px", flexWrap: "wrap" }}>
         <div>
+          <PageCategoryLabel label="Community" />
           <h1
             style={{
               fontSize: "32px",

--- a/founder-sprint/src/app/(dashboard)/founders/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/founders/page.tsx
@@ -4,6 +4,7 @@ import { getCurrentUser } from "@/lib/permissions";
 import { getAllMembers, getAllMemberStats } from "@/actions/directory";
 import { getFollowingIdsForUser } from "@/actions/follow";
 import { FollowButton } from "@/components/feed/FollowButton";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { SearchBar } from "./SearchBar";
 import type { UserRole } from "@/types";
 
@@ -86,6 +87,7 @@ export default async function FoundersPage({
   return (
     <div>
       <div style={{ marginBottom: "32px" }}>
+        <PageCategoryLabel label="Community" />
         <h1
           style={{
             fontSize: "32px",

--- a/founder-sprint/src/app/(dashboard)/groups/GroupsList.tsx
+++ b/founder-sprint/src/app/(dashboard)/groups/GroupsList.tsx
@@ -7,6 +7,7 @@ import { Modal } from "@/components/ui/Modal";
 import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { createGroup } from "@/actions/group";
 
 interface Group {
@@ -50,7 +51,10 @@ export function GroupsList({ groups, isAdmin }: GroupsListProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Companies</h1>
+        <div>
+          <PageCategoryLabel label="Batch" />
+          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Groups</h1>
+        </div>
         {isAdmin && (
           <Button onClick={() => setIsModalOpen(true)}>Create Company</Button>
         )}

--- a/founder-sprint/src/app/(dashboard)/messages/ConversationList.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/ConversationList.tsx
@@ -6,6 +6,7 @@ import { format, isThisYear } from "date-fns";
 import type { ConversationListItem } from "@/actions/messaging";
 import { Avatar } from "@/components/ui/Avatar";
 import { GroupAvatar } from "@/components/ui/GroupAvatar";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 
 interface ConversationListProps {
   conversations: ConversationListItem[];
@@ -124,9 +125,12 @@ export default function ConversationList({
       {/* Header */}
       <div style={{ padding: "16px", borderBottom: "1px solid #e0e0e0" }}>
         <div className="flex" style={{ alignItems: "center", justifyContent: "space-between", marginBottom: "12px" }}>
-          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26", margin: 0 }}>
-            Messages
-          </h1>
+          <div>
+            <PageCategoryLabel label="Community" />
+            <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26", margin: 0 }}>
+              Messages
+            </h1>
+          </div>
           <div className="flex" style={{ gap: "8px" }}>
             <button
               onClick={onComposeClick}

--- a/founder-sprint/src/app/(dashboard)/office-hours/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/office-hours/page.tsx
@@ -2,6 +2,7 @@ import { getCurrentUser } from "@/lib/permissions";
 import { completeExpiredSlots, getOfficeHourBatchContext, getOfficeHourRequesterStats, getOfficeHourSlots } from "@/actions/office-hour";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { OfficeHoursList } from "./OfficeHoursList";
 
 export const revalidate = 60;
@@ -31,7 +32,10 @@ export default async function OfficeHoursPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Office Hours</h1>
+        <div>
+          <PageCategoryLabel label="Batch" />
+          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Office Hours</h1>
+        </div>
       </div>
       <OfficeHoursList
         user={user}

--- a/founder-sprint/src/app/(dashboard)/questions/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/questions/page.tsx
@@ -2,6 +2,7 @@ import { getCurrentUser } from "@/lib/permissions";
 import { getQuestions } from "@/actions/question";
 import { redirect } from "next/navigation";
 import { QuestionsList } from "./QuestionsList";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { Button } from "@/components/ui/Button";
 import Link from "next/link";
 
@@ -21,6 +22,7 @@ export default async function QuestionsPage() {
     <div className="container" style={{ maxWidth: 900 }}>
       <div className="flex items-center justify-between mb-8">
         <div>
+          <PageCategoryLabel label="Batch" />
           <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26", marginBottom: "8px" }}>Questions</h1>
           <p style={{ color: "var(--color-foreground-secondary)" }}>
             Ask questions and get answers from mentors and admins

--- a/founder-sprint/src/app/(dashboard)/schedule/page.tsx
+++ b/founder-sprint/src/app/(dashboard)/schedule/page.tsx
@@ -3,6 +3,7 @@ import { getScheduleItems } from "@/actions/schedule";
 import { getOfficeHourBatchContext } from "@/actions/office-hour";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { ScheduleView } from "./ScheduleView";
 import { startOfWeek, startOfMonth, endOfWeek, endOfMonth, parse, isValid } from "date-fns";
 import type { VisibleScheduleFilter } from "@/types/schedule";
@@ -72,7 +73,10 @@ export default async function SchedulePage({
 
   return (
     <div className="space-y-6">
-      <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Schedule</h1>
+      <div>
+        <PageCategoryLabel label="Batch" />
+        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Schedule</h1>
+      </div>
       <ScheduleView
         items={items}
         month={monthDate.toISOString()}

--- a/founder-sprint/src/app/(dashboard)/sessions/SessionsList.tsx
+++ b/founder-sprint/src/app/(dashboard)/sessions/SessionsList.tsx
@@ -15,6 +15,7 @@ import { TIMEZONE_OPTIONS } from "@/lib/timezone";
 import { useToast } from "@/hooks/useToast";
 import { BatchSelect, type BatchOption } from "@/components/ui/BatchSelect";
 import { CompanySelect, type CompanyOption } from "@/components/ui/CompanySelect";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { addMinutesToTimeValue, getTimeRangeDurationMinutes } from "@/lib/schedule-form";
 
 interface Session {
@@ -251,7 +252,10 @@ export function SessionsList({ sessions, isAdmin, batchOptions, companyOptions, 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Sessions</h1>
+        <div>
+          <PageCategoryLabel label="Batch" />
+          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Sessions</h1>
+        </div>
         {isAdmin && (
           <Button onClick={() => setIsModalOpen(true)}>Create Session</Button>
         )}

--- a/founder-sprint/src/app/(dashboard)/submissions/SubmissionsDashboard.tsx
+++ b/founder-sprint/src/app/(dashboard)/submissions/SubmissionsDashboard.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Button } from "@/components/ui/Button";
+import { PageCategoryLabel } from "@/components/layout/PageCategoryLabel";
 import { formatDate, getDisplayName } from "@/lib/utils";
 import { getAssignmentNonSubmitters, sendAssignmentDeadlineReminders } from "@/actions/assignment";
 import { useToast } from "@/hooks/useToast";
@@ -156,7 +157,10 @@ export function SubmissionsDashboard({ submissions, assignments }: SubmissionsDa
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Submissions Dashboard</h1>
+        <div>
+          <PageCategoryLabel label="Batch" />
+          <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Submissions Dashboard</h1>
+        </div>
       </div>
 
       <div className="card">

--- a/founder-sprint/src/components/layout/PageCategoryLabel.tsx
+++ b/founder-sprint/src/components/layout/PageCategoryLabel.tsx
@@ -1,0 +1,16 @@
+export function PageCategoryLabel({ label }: { label: string }) {
+  return (
+    <p
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: "1.5px",
+        textTransform: "uppercase",
+        color: "#999999",
+        margin: "0 0 4px 0",
+      }}
+    >
+      {label}
+    </p>
+  );
+}


### PR DESCRIPTION
## Why

Two related pieces of feedback:

1. When you navigate to `/founders`, `/companies`, `/messages`, `/schedule`, `/assignments`, `/office-hours`, `/questions`, `/sessions`, `/submissions`, or `/groups`, the page itself does not show which top-nav dropdown (Community vs. Batch) the page belongs to. The dropdown closes after navigation, so the only on-screen indicator was the URL.
2. The `/groups` page heading actually renders as **"Companies"** — a copy-paste leftover from when this page was scaffolded from the companies page.

## What changes

Adds one tiny shared component and renders it above each landing page's existing `<h1>`.

**New (~15 lines, no state):** `src/components/layout/PageCategoryLabel.tsx`

```tsx
<PageCategoryLabel label="Community" />
<h1>Founders</h1>
```

Renders a small uppercase eyebrow text (`COMMUNITY`, `BATCH`) immediately above the page heading. Styling matches the existing cream/tan palette (`#999999`, 11px, letter-spacing 1.5px, weight 600).

**Mapping** (mirrors `BookfaceTopNav`'s actual dropdown grouping):

| Eyebrow | Pages |
|---------|-------|
| `COMMUNITY` | Founders, Companies, Messages |
| `BATCH` | Schedule, Assignments, Office Hours, Questions, Sessions, Submissions, Groups |

Sessions/Submissions/Groups aren't surfaced in the top-nav dropdown today, but they are batch-scoped in the data model, so `Batch` matches the user's mental model.

**Special case — Messages:** the `/messages` route uses a full-bleed two-pane chat layout, not a normal centered page. The `Messages` `<h1>` lives inside the conversation-list sidebar (`ConversationList.tsx`), so the eyebrow is added there too.

**Typo fix:** `src/app/(dashboard)/groups/GroupsList.tsx` — heading text changed from `"Companies"` to `"Groups"`. The form labels, placeholders, and modal title inside that same component (`Create Company`, `Company Name`, etc.) still say "Company" — those are the same copy-paste mistake, but the user's complaint was specifically about the page heading and I'm keeping this PR's scope tight. Quick follow-up cleanup welcome.

## Files

| Type | Path |
|------|------|
| New | `src/components/layout/PageCategoryLabel.tsx` |
| Modified | `src/app/(dashboard)/founders/page.tsx` |
| Modified | `src/app/(dashboard)/companies/page.tsx` |
| Modified | `src/app/(dashboard)/messages/ConversationList.tsx` |
| Modified | `src/app/(dashboard)/schedule/page.tsx` |
| Modified | `src/app/(dashboard)/assignments/AssignmentsList.tsx` |
| Modified | `src/app/(dashboard)/office-hours/page.tsx` |
| Modified | `src/app/(dashboard)/questions/page.tsx` |
| Modified | `src/app/(dashboard)/sessions/SessionsList.tsx` |
| Modified | `src/app/(dashboard)/submissions/SubmissionsDashboard.tsx` |
| Modified + typo fix | `src/app/(dashboard)/groups/GroupsList.tsx` |

No schema, no data, no auth, no migration. No file overlap with the messages-loading PR. The companies/page.tsx edit is in the heading section (top of file); the companies-website PR's edit is in the card render block (~line 360+) — git's three-way merge handles both with no rebase needed.

## Verification

- `tsc --noEmit` clean across all modified files (errors that surface on a fresh worktree are pre-existing, caused by Prisma client not yet being generated; unrelated to this PR).
- LSP diagnostics clean on every changed file.
- Manual: each page shows the correct eyebrow above its heading; Groups heading now reads `Groups`.