### PR TITLE
Fix infinite loading when navigating to /messages?conversation=ID from a profile

### DIFF
--- a/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
@@ -93,37 +93,48 @@ export default function MessagesClient({
     return () => clearInterval(interval);
   }, [selectedConversationId]);
 
-  // Handle conversation selection
-  const handleSelectConversation = async (conversationId: string) => {
-    setSelectedConversationId(conversationId);
+  useEffect(() => {
+    if (!selectedConversationId) {
+      setConversationDetail(null);
+      setMessages([]);
+      return;
+    }
+
+    const idForThisRun = selectedConversationId;
+    let cancelled = false;
     setMessagesLoading(true);
+
+    Promise.all([
+      getConversation(idForThisRun),
+      getMessages(idForThisRun),
+    ])
+      .then(([detailResult, messagesResult]) => {
+        if (cancelled) return;
+        if (detailResult.success) setConversationDetail(detailResult.data);
+        if (messagesResult.success) setMessages(messagesResult.data.messages);
+        setMessagesLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setMessagesLoading(false);
+      });
+
+    markConversationRead(idForThisRun).then(() => {
+      if (cancelled) return;
+      setConversations(prev =>
+        prev.map(c =>
+          c.id === idForThisRun ? { ...c, unreadCount: 0 } : c
+        )
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedConversationId]);
+
+  const handleSelectConversation = (conversationId: string) => {
+    setSelectedConversationId(conversationId);
     router.push(`/messages?conversation=${conversationId}`);
-
-    // Fetch conversation details and messages
-    const [detailResult, messagesResult] = await Promise.all([
-      getConversation(conversationId),
-      getMessages(conversationId),
-    ]);
-
-    if (detailResult.success) {
-      setConversationDetail(detailResult.data);
-    }
-
-    if (messagesResult.success) {
-      setMessages(messagesResult.data.messages);
-    }
-
-    setMessagesLoading(false);
-
-    // Mark as read
-    await markConversationRead(conversationId);
-
-    // Update the unread count in the local conversations list
-    setConversations(prev =>
-      prev.map(c =>
-        c.id === conversationId ? { ...c, unreadCount: 0 } : c
-      )
-    );
   };
 
   const handleSendMessage = async (


### PR DESCRIPTION
## What broke

Clicking **Message** on someone's profile sends the user to `/messages?conversation=ID` and shows a loading spinner that **never resolves**. The conversation thread never loads.

## Root cause

`MessagesClient` initializes `selectedConversationId` from the URL on mount:

```tsx
const [selectedConversationId, setSelectedConversationId] = useState<string | null>(
  searchParams.get("conversation"),
);
```

…so when you arrive via URL, the state is correct from frame 0. **But the only code that called `getConversation()` / `getMessages()` was inside `handleSelectConversation`**, which is only invoked from a click handler in the conversation list. URL-driven selection never triggered a fetch — hence the eternal spinner.

Bug introduced in `297ebf9` (Apr 27, "Make founder messaging handle images and direct starts").

## Fix

Lift the fetch out of the click handler and into a `useEffect` keyed on `selectedConversationId`. The effect is now the **single owner of "load conversation N's data"** — it fires identically whether the value came from a click, the URL, or any other future trigger.

```tsx
useEffect(() => {
  if (!selectedConversationId) {
    setConversationDetail(null);
    setMessages([]);
    return;
  }

  const idForThisRun = selectedConversationId;
  let cancelled = false;
  setMessagesLoading(true);

  Promise.all([getConversation(idForThisRun), getMessages(idForThisRun)])
    .then(([detailResult, messagesResult]) => {
      if (cancelled) return;
      if (detailResult.success) setConversationDetail(detailResult.data);
      if (messagesResult.success) setMessages(messagesResult.data.messages);
      setMessagesLoading(false);
    })
    .catch(() => {
      if (!cancelled) setMessagesLoading(false);
    });

  markConversationRead(idForThisRun).then(() => {
    if (cancelled) return;
    setConversations(prev =>
      prev.map(c => (c.id === idForThisRun ? { ...c, unreadCount: 0 } : c)),
    );
  });

  return () => { cancelled = true; };
}, [selectedConversationId]);

const handleSelectConversation = (conversationId: string) => {
  setSelectedConversationId(conversationId);
  router.push(`/messages?conversation=${conversationId}`);
};
```

### Side effects preserved

- `markConversationRead` and the local `unreadCount` clear used to live inside `handleSelectConversation`. Both now live inside the same effect, so URL-driven loads also mark the thread as read (correct behavior — if you're viewing the thread, it should clear unread, regardless of how you got there).
- The 3-second polling effect (line 84) is unchanged.
- `await handleSelectConversation(...)` callers in `handleJoinGroup`, `handleGroupCreated`, and `handleStartDirectMessage` keep working — `await` on a void return resolves immediately, and none of those functions runs anything after the call.

### Race protection

A `cancelled` flag in the cleanup function makes older fetch resolutions no-ops if the user rapidly switches A → B → C — only the latest selection's data wins. `idForThisRun` is captured into a const at the start of the effect run so the closure is stable.

## Verification

- `tsc --noEmit` clean on the modified file.
- LSP diagnostics clean.
- Manual flows covered:
  1. From Founders/Companies, click someone's profile → click **Message** → lands on `/messages?conversation=ID`, thread loads (no eternal spinner).
  2. From Messages page, click a conversation in the list → still loads (regression check).
  3. Reload while on `/messages?conversation=ID` → still loads.
  4. Switch rapidly between two conversations → no flicker of one thread's data inside another (race-protection check).

## Scope

Single file: `founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx`. No schema, no auth, no migration. No file overlap with the other two feedback PRs.