### PR TITLE
Address Copilot review feedback on PRs #97 and #98

### DIFF
--- a/founder-sprint/src/app/(dashboard)/groups/GroupsList.tsx
+++ b/founder-sprint/src/app/(dashboard)/groups/GroupsList.tsx
@@ -56,17 +56,17 @@ export function GroupsList({ groups, isAdmin }: GroupsListProps) {
           <h1 style={{ fontSize: "32px", fontWeight: 600, fontFamily: '"Libre Caslon Condensed", Georgia, serif', color: "#2F2C26" }}>Groups</h1>
         </div>
         {isAdmin && (
-          <Button onClick={() => setIsModalOpen(true)}>Create Company</Button>
+          <Button onClick={() => setIsModalOpen(true)}>Create Group</Button>
         )}
       </div>
 
       {groups.length === 0 ? (
         <EmptyState
-          title="No companies yet"
-          description="Companies will appear here once created"
+          title="No groups yet"
+          description="Groups will appear here once created"
           action={
             isAdmin ? (
-              <Button onClick={() => setIsModalOpen(true)}>Create First Company</Button>
+              <Button onClick={() => setIsModalOpen(true)}>Create First Group</Button>
             ) : undefined
           }
         />
@@ -107,7 +107,7 @@ export function GroupsList({ groups, isAdmin }: GroupsListProps) {
         </div>
       )}
 
-      <Modal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Create Company">
+      <Modal open={isModalOpen} onClose={() => setIsModalOpen(false)} title="Create Group">
         <form onSubmit={handleSubmit} className="space-y-4">
       {error && (
         <div className="form-error p-3 rounded-lg text-sm">
@@ -117,15 +117,15 @@ export function GroupsList({ groups, isAdmin }: GroupsListProps) {
 
           <Input
             name="name"
-            label="Company Name"
-            placeholder="Acme Corp"
+            label="Group Name"
+            placeholder="Founders Circle"
             required
           />
 
           <Textarea
             name="description"
             label="Description"
-            placeholder="Brief description of the company"
+            placeholder="Brief description of the group"
             rows={3}
           />
 
@@ -139,7 +139,7 @@ export function GroupsList({ groups, isAdmin }: GroupsListProps) {
               Cancel
             </Button>
             <Button type="submit" loading={isPending}>
-              Create Company
+              Create Group
             </Button>
           </div>
         </form>

--- a/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
+++ b/founder-sprint/src/app/(dashboard)/messages/MessagesClient.tsx
@@ -33,7 +33,9 @@ export default function MessagesClient({
   );
   const [conversationDetail, setConversationDetail] = useState<ConversationDetail | null>(null);
   const [messages, setMessages] = useState<MessageItem[]>([]);
-  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [messagesLoading, setMessagesLoading] = useState<boolean>(
+    !!searchParams.get("conversation")
+  );
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<ConversationListItem[] | null>(null);
   const [browseGroupsOpen, setBrowseGroupsOpen] = useState(false);
@@ -97,6 +99,7 @@ export default function MessagesClient({
     if (!selectedConversationId) {
       setConversationDetail(null);
       setMessages([]);
+      setMessagesLoading(false);
       return;
     }
 
@@ -134,6 +137,7 @@ export default function MessagesClient({
 
   const handleSelectConversation = (conversationId: string) => {
     setSelectedConversationId(conversationId);
+    setMessagesLoading(true);
     router.push(`/messages?conversation=${conversationId}`);
   };
 


### PR DESCRIPTION
## Why

Follow-ups to Copilot's review of [#97](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/pull/97) (eyebrow labels) and [#98](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/pull/98) (messages URL fix), both already merged. Three of Copilot's four comments were real issues; one was stylistic and skipped.

Single PR with two commits, one per parent PR.

## Commit 1 — `Address Copilot review: prevent loading-state inconsistencies`

`src/app/(dashboard)/messages/MessagesClient.tsx`

### Issue 1 (Medium): Stale-data flicker on selection

PR #98 moved `setMessagesLoading(true)` from `handleSelectConversation` into the new `useEffect`. Effects run after commit, so there is one render frame after a click (or initial mount from `?conversation=`) where `selectedConversationId` is the new id but `messagesLoading` is still `false`. `ConversationThread` can briefly show the previous conversation's data — the same class of visual confusion the original click handler avoided by setting both flags synchronously.

**Fix:** set `messagesLoading` synchronously in two more places:

```tsx
const handleSelectConversation = (conversationId: string) => {
  setSelectedConversationId(conversationId);
  setMessagesLoading(true);  // restored — was lost in PR #98
  router.push(`/messages?conversation=${conversationId}`);
};

const [messagesLoading, setMessagesLoading] = useState<boolean>(
  !!searchParams.get("conversation"),  // initial-mount case for URL flow
);
```

### Issue 2 (Low): `messagesLoading` stuck `true` after cancellation

When the user navigates away (back/delete) while a fetch is in flight, the cleanup flips `cancelled = true` and both `.then` and `.catch` short-circuit, never calling `setMessagesLoading(false)`. The flag stays `true` with no conversation selected — currently invisible (`ConversationThread` hides itself when `conversationId` is null) but the state is inconsistent and could mislead future UI that reads the flag.

**Fix:** also call `setMessagesLoading(false)` in the `!selectedConversationId` branch of the effect.

## Commit 2 — `Address Copilot review: rename remaining 'Company' copy on Groups page`

`src/app/(dashboard)/groups/GroupsList.tsx`

PR #97 fixed the visible `<h1>` typo but left the rest of the copy-paste leftovers from when this page was scaffolded from the companies page. Copilot called this out.

| Where | Before | After |
|---|---|---|
| Admin button | `Create Company` | `Create Group` |
| EmptyState title | `No companies yet` | `No groups yet` |
| EmptyState description | `Companies will appear here once created` | `Groups will appear here once created` |
| EmptyState action | `Create First Company` | `Create First Group` |
| Modal title | `Create Company` | `Create Group` |
| Input label | `Company Name` | `Group Name` |
| Input placeholder | `Acme Corp` | `Founders Circle` |
| Textarea placeholder | `Brief description of the company` | `Brief description of the group` |
| Modal submit | `Create Company` | `Create Group` |

`createGroup` server action and `Group` shape are unchanged — pure copy fix.

## Skipped Copilot suggestion

Copilot also suggested narrowing `PageCategoryLabel`'s `label` prop from `string` to a union (`"Community" | "Batch"`). Stylistic only — none of the 11 callsites have a typo, and a union locks in the value set. Left as `string` for flexibility. Easy to tighten later if the value set is ever standardized.

## Verification

- `tsc --noEmit` clean on both modified files.
- LSP diagnostics clean.
- No data, no schema, no auth, no migration.