### PR TITLE
Extend invite_token cookie TTL to match 7-day invitation lifetime

### DIFF
--- a/founder-sprint/src/app/api/invite/accept/route.ts
+++ b/founder-sprint/src/app/api/invite/accept/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
-    maxAge: 60 * 60,
+    maxAge: 7 * 24 * 60 * 60,
     path: "/",
   });
 


### PR DESCRIPTION
## Summary

The `invite_token` cookie set by `/api/invite/accept` had a 1-hour TTL, while invitation tokens themselves are valid for 7 days. This mismatch caused login failures for invited users whose LinkedIn-registered email differs from the invitation email (e.g. Google Workspace aliases like `kyle@company.com` vs `kyle.ryu@company.com`).

## Problem

The auth callback ([`src/app/(auth)/auth/callback/route.ts:93-127`](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/blob/main/founder-sprint/src/app/%28auth%29/auth/callback/route.ts#L93-L127)) has a fallback path: when the LinkedIn email doesn't match any user record, it uses the `invite_token` cookie to find the pending invitation and update the invited user's email to match what LinkedIn returned. This is the only mechanism that bridges email mismatches.

But the cookie was only valid for 1 hour ([`src/app/api/invite/accept/route.ts:33`](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/blob/main/founder-sprint/src/app/api/invite/accept/route.ts#L33)). If a user:

- Clicked the email invite link, then deferred login for >1 hour, or
- Bookmarked / went directly to \`/login\` without re-clicking the invite link

…the cookie was gone by the time LinkedIn OAuth completed, the fallback couldn't run, and they got redirected to \`/no-batch\` with no recovery option visible in the UI. This was hit in production by a real FS6 user with an email alias mismatch.

## Fix

Change \`maxAge\` from \`60 * 60\` (1 hour) to \`7 * 24 * 60 * 60\` (7 days), matching the invitation token lifetime set in [\`src/actions/user-management.ts:299-300\`](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/blob/main/founder-sprint/src/actions/user-management.ts#L299-L300) and the 7-day window check in the callback ([line 148](https://github.com/SL-IT-AMAZING/founder-sprint-workspace/blob/main/founder-sprint/src/app/%28auth%29/auth/callback/route.ts#L148)).

## Risk

Low. Cookie is httpOnly + sameSite=lax + secure (in prod), and the underlying token is single-use (\`InvitationToken.usedAt\` invalidates it on first successful claim). Extending TTL doesn't expand the attack surface in any meaningful way.

## Out of scope (follow-up candidates)

- Replace the \`/no-batch\` page with a recovery affordance (\"resend my invite\" button)
- Surface a clearer error when the LinkedIn email doesn't match any invitation, instead of generic \`/no-batch\`