### PR TITLE
Surface invite email failures instead of reporting them as success

### DIFF
--- a/founder-sprint/src/actions/user-management.ts
+++ b/founder-sprint/src/actions/user-management.ts
@@ -4,11 +4,12 @@ import { prisma } from "@/lib/prisma";
 import { getCurrentUser, isCurrentUserSuperAdmin, requireRole, isAdmin } from "@/lib/permissions";
 import { requireActiveBatch } from "@/lib/batch-gate";
 import { sendInvitationEmail } from "@/lib/email";
+import { getRecipientEmail } from "@/lib/email-routing";
 import { ASSIGNABLE_ROLES, isRoleBelow } from "@/lib/role-hierarchy";
 import { revalidatePath, revalidateTag as revalidateTagBase } from "next/cache";
 import { randomUUID } from "crypto";
 import { z } from "zod";
-import type { ActionResult, UserRole } from "@/types";
+import type { ActionResult, BulkInviteRow, UserRole } from "@/types";
 
 const revalidateTag = (tag: string) => revalidateTagBase(tag, "default");
 
@@ -83,9 +84,24 @@ async function createAuditLogEntry(params: {
   });
 }
 
+/**
+ * Outcome of a single invite attempt.
+ *
+ * `emailSent` is the source of truth for "did the invitee actually get mailed".
+ * It is false when the membership was activated directly (no invite email is
+ * sent in that flow), when SMTP is unconfigured or errored, and when the
+ * recipient was filtered out as undeliverable.
+ */
+type InviteOutcome = {
+  id: string;
+  inviteLink?: string;
+  membershipStatus: "active" | "invited";
+  emailSent: boolean;
+};
+
 async function inviteUserCore(
   params: InviteUserParams
-): Promise<ActionResult<{ id: string; inviteLink?: string; membershipStatus: "active" | "invited" }>> {
+): Promise<ActionResult<InviteOutcome>> {
   const { email, name, role, batchId, founderId, companyId } = params;
   const batchRole = getBatchRoleForAssignment(role);
 
@@ -246,8 +262,8 @@ async function inviteUserCore(
 
       return {
         success: true,
-        data: { id: activatedMembership.id, membershipStatus: "active" },
-        warning: "Existing user was added directly to this batch.",
+        data: { id: activatedMembership.id, membershipStatus: "active", emailSent: false },
+        warning: "Existing user was added directly to this batch. No invitation email was sent.",
       };
     }
 
@@ -291,8 +307,8 @@ async function inviteUserCore(
   if (membershipStatus === "active") {
     return {
       success: true,
-      data: { id: userBatch.id, membershipStatus },
-      warning: "Existing user was added directly to this batch.",
+      data: { id: userBatch.id, membershipStatus, emailSent: false },
+      warning: "Existing user was added directly to this batch. No invitation email was sent.",
     };
   }
 
@@ -313,8 +329,10 @@ async function inviteUserCore(
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const inviteLink = `${appUrl}/invite/${token}`;
 
+  const recipientEmail = getRecipientEmail(invitedUser);
+
   const emailResult = await sendInvitationEmail({
-    to: email,
+    to: recipientEmail,
     inviteeName: name || undefined,
     batchName: batch.name,
     role,
@@ -322,18 +340,27 @@ async function inviteUserCore(
   });
 
   if (!emailResult.success) {
-    console.warn(`Failed to send invitation email to ${email}:`, emailResult.error);
+    console.warn(`Failed to send invitation email to ${recipientEmail}:`, emailResult.error);
     return {
       success: true,
-      data: { id: userBatch.id, inviteLink, membershipStatus },
+      data: { id: userBatch.id, inviteLink, membershipStatus, emailSent: false },
       warning: "User was invited but the email could not be sent. Please share the invite link directly.",
     };
   }
 
-  return { success: true, data: { id: userBatch.id, inviteLink, membershipStatus } };
+  if (emailResult.skipped) {
+    console.warn(`Invitation email skipped for undeliverable test address: ${recipientEmail}`);
+    return {
+      success: true,
+      data: { id: userBatch.id, inviteLink, membershipStatus, emailSent: false },
+      warning: `No email was sent — ${recipientEmail} is a test address. Share the invite link directly.`,
+    };
+  }
+
+  return { success: true, data: { id: userBatch.id, inviteLink, membershipStatus, emailSent: true } };
 }
 
-export async function inviteUser(formData: FormData): Promise<ActionResult<{ id: string; inviteLink?: string; membershipStatus: "active" | "invited" }>> {
+export async function inviteUser(formData: FormData): Promise<ActionResult<InviteOutcome>> {
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
   const canAssignSuperAdmin = await isCurrentUserSuperAdmin();
@@ -374,7 +401,7 @@ export async function inviteUser(formData: FormData): Promise<ActionResult<{ id:
 }
 
 export async function bulkInviteUsers(formData: FormData): Promise<ActionResult<{
-  results: Array<{ email: string; success: boolean; error?: string; inviteLink?: string; membershipStatus?: "active" | "invited" }>;
+  results: BulkInviteRow[];
 }>> {
   const user = await getCurrentUser();
   if (!user) return { success: false, error: "Not authenticated" };
@@ -437,7 +464,7 @@ export async function bulkInviteUsers(formData: FormData): Promise<ActionResult<
     }
   }
 
-  const results: Array<{ email: string; success: boolean; error?: string; inviteLink?: string; membershipStatus?: "active" | "invited" }> = [];
+  const results: BulkInviteRow[] = [];
 
   for (const email of uniqueEmails) {
         const result = await inviteUserCore({
@@ -448,7 +475,14 @@ export async function bulkInviteUsers(formData: FormData): Promise<ActionResult<
         });
 
     if (result.success) {
-      results.push({ email, success: true, inviteLink: result.data.inviteLink, membershipStatus: result.data.membershipStatus });
+      results.push({
+        email,
+        success: true,
+        inviteLink: result.data.inviteLink,
+        membershipStatus: result.data.membershipStatus,
+        emailSent: result.data.emailSent,
+        note: result.warning,
+      });
     } else {
       results.push({ email, success: false, error: result.error });
     }
@@ -461,6 +495,7 @@ export async function bulkInviteUsers(formData: FormData): Promise<ActionResult<
 
   const successCount = results.filter((r) => r.success).length;
   const failCount = results.filter((r) => !r.success).length;
+  const notMailedCount = results.filter((r) => r.success && !r.emailSent).length;
 
   if (successCount === 0) {
     return {
@@ -469,10 +504,16 @@ export async function bulkInviteUsers(formData: FormData): Promise<ActionResult<
     };
   }
 
+  const warningParts: string[] = [];
+  if (failCount > 0) warningParts.push(`${failCount} failed`);
+  if (notMailedCount > 0) warningParts.push(`${notMailedCount} without an email`);
+
   return {
     success: true,
     data: { results },
-    ...(failCount > 0 ? { warning: `${successCount} invited, ${failCount} failed` } : {}),
+    ...(warningParts.length > 0
+      ? { warning: `${successCount} invited, ${warningParts.join(", ")}` }
+      : {}),
   };
 }
 
@@ -531,7 +572,7 @@ export async function inviteBatchMembersFromSource(input: {
     return roleOrder[aRole] - roleOrder[bRole];
   });
 
-  const results: Array<{ email: string; success: boolean; error?: string; inviteLink?: string; membershipStatus?: "active" | "invited" }> = [];
+  const results: BulkInviteRow[] = [];
 
   for (const member of sourceMembers) {
     const role = (member.user.role === "super_admin" ? "super_admin" : member.role) as InviteUserParams["role"];
@@ -552,6 +593,8 @@ export async function inviteBatchMembersFromSource(input: {
         success: true,
         inviteLink: result.data.inviteLink,
         membershipStatus: result.data.membershipStatus,
+        emailSent: result.data.emailSent,
+        note: result.warning,
       });
     } else {
       results.push({ email: member.user.email, success: false, error: result.error });
@@ -565,6 +608,7 @@ export async function inviteBatchMembersFromSource(input: {
 
   const successCount = results.filter((r) => r.success).length;
   const failCount = results.length - successCount;
+  const notMailedCount = results.filter((r) => r.success && !r.emailSent).length;
 
   if (successCount === 0) {
     return {
@@ -573,10 +617,16 @@ export async function inviteBatchMembersFromSource(input: {
     };
   }
 
+  const warningParts: string[] = [];
+  if (failCount > 0) warningParts.push(`${failCount} failed`);
+  if (notMailedCount > 0) warningParts.push(`${notMailedCount} without an email`);
+
   return {
     success: true,
     data: { results },
-    ...(failCount > 0 ? { warning: `${successCount} invited, ${failCount} failed` } : {}),
+    ...(warningParts.length > 0
+      ? { warning: `${successCount} invited, ${warningParts.join(", ")}` }
+      : {}),
   };
 }
 
@@ -926,6 +976,7 @@ export async function resendInvite(
           id: true,
           email: true,
           name: true,
+          notificationEmail: true,
         },
       },
       batch: {
@@ -972,8 +1023,10 @@ export async function resendInvite(
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const inviteLink = `${appUrl}/invite/${token}`;
 
+  const recipientEmail = getRecipientEmail(targetMembership.user);
+
   const emailResult = await sendInvitationEmail({
-    to: targetMembership.user.email,
+    to: recipientEmail,
     inviteeName: targetMembership.user.name || undefined,
     batchName: targetMembership.batch.name,
     role: targetMembership.role,
@@ -997,10 +1050,20 @@ export async function resendInvite(
   revalidateTag("current-user");
 
   if (!emailResult.success) {
+    console.warn(`Failed to resend invitation email to ${recipientEmail}:`, emailResult.error);
     return {
       success: true,
       data: { inviteLink },
       warning: "Invite was renewed but the email could not be sent. Share the invite link directly.",
+    };
+  }
+
+  if (emailResult.skipped) {
+    console.warn(`Invitation email skipped for undeliverable test address: ${recipientEmail}`);
+    return {
+      success: true,
+      data: { inviteLink },
+      warning: `Invite was renewed but no email was sent — ${recipientEmail} is a test address. Share the invite link directly.`,
     };
   }
 

--- a/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
+++ b/founder-sprint/src/app/(dashboard)/admin/users/UserManagement.tsx
@@ -39,7 +39,7 @@ function getRoleDisplayName(role: string): string {
 }
 import { getBatchStatusLabel } from "@/lib/batch-utils";
 import { useToast } from "@/hooks/useToast";
-import type { UserRole, BatchStatus } from "@/types";
+import type { UserRole, BatchStatus, BulkInviteRow } from "@/types";
 
 interface Batch {
   id: string;
@@ -174,7 +174,7 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
   const [selectedRole, setSelectedRole] = useState("founder");
   const [inviteMode, setInviteMode] = useState<"single" | "bulk">("single");
   const [bulkEmails, setBulkEmails] = useState<string[]>([]);
-  const [bulkResults, setBulkResults] = useState<Array<{ email: string; success: boolean; error?: string; inviteLink?: string }> | null>(null);
+  const [bulkResults, setBulkResults] = useState<BulkInviteRow[] | null>(null);
   const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
   const [isLoadingAudit, setIsLoadingAudit] = useState(false);
   const [activityEntries, setActivityEntries] = useState<FounderActivityEntry[]>([]);
@@ -193,6 +193,28 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       if (linkCopiedTimerRef.current) clearTimeout(linkCopiedTimerRef.current);
     };
   }, []);
+
+  /**
+   * Server actions reject on any unhandled server-side error (Prisma, audit
+   * log write, revalidate). Without this wrapper the rejection escapes the
+   * transition and the admin sees nothing at all — no toast, no error, no
+   * state change. Every failure has to land somewhere visible.
+   */
+  const runAction = useCallback(
+    async <T,>(
+      action: () => Promise<T>,
+      onError: (message: string) => void
+    ): Promise<T | null> => {
+      try {
+        return await action();
+      } catch (err) {
+        console.error("User management action failed:", err);
+        onError("Something went wrong. Please try again.");
+        return null;
+      }
+    },
+    []
+  );
 
   // Load users function
   const loadUsers = useCallback((batchId: string) => {
@@ -324,7 +346,8 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     const formData = new FormData(e.currentTarget);
 
     startTransition(async () => {
-      const result = await inviteUser(formData);
+      const result = await runAction(() => inviteUser(formData), setFormError);
+      if (!result) return;
 
       if (result.success) {
         setIsInviteModalOpen(false);
@@ -356,12 +379,16 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     formData.set("emails", bulkEmails.join("\n"));
 
     startTransition(async () => {
-      const result = await bulkInviteUsers(formData);
+      const result = await runAction(() => bulkInviteUsers(formData), setFormError);
+      if (!result) return;
 
       if (result.success) {
         setBulkResults(result.data.results);
         setBulkEmails([]);
         loadUsers(selectedBatchId);
+        if (result.warning) {
+          toast.warning(result.warning);
+        }
       } else {
         setFormError(result.error);
       }
@@ -385,11 +412,16 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     setFormError("");
 
     startTransition(async () => {
-      const result = await inviteBatchMembersFromSource({
-        sourceBatchId: sourceInviteBatchId,
-        targetBatchId: selectedBatchId,
-        userIds: selectedSourceUserIds,
-      });
+      const result = await runAction(
+        () =>
+          inviteBatchMembersFromSource({
+            sourceBatchId: sourceInviteBatchId,
+            targetBatchId: selectedBatchId,
+            userIds: selectedSourceUserIds,
+          }),
+        setFormError
+      );
+      if (!result) return;
 
       if (result.success) {
         setBulkResults(result.data.results);
@@ -412,7 +444,11 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const handleRoleChange = async (userBatch: BatchUser, newRole: string) => {
     startTransition(async () => {
-      const result = await updateUserRole(userBatch.userId, userBatch.batchId, newRole as UserRole);
+      const result = await runAction(
+        () => updateUserRole(userBatch.userId, userBatch.batchId, newRole as UserRole),
+        toast.error
+      );
+      if (!result) return;
 
       if (result.success) {
         refreshCurrentScope();
@@ -429,7 +465,12 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
       : (userBatch.additionalRoles || []).filter((additionalRole) => additionalRole !== role);
 
     startTransition(async () => {
-      const result = await updateAdditionalRoles(userBatch.userId, userBatch.batchId, nextRoles);
+      const result = await runAction(
+        () => updateAdditionalRoles(userBatch.userId, userBatch.batchId, nextRoles),
+        toast.error
+      );
+      if (!result) return;
+
       if (result.success) {
         refreshCurrentScope();
         refreshBatchPanelsIfVisible(userBatch.batchId);
@@ -509,7 +550,8 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const handleRemoveUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await removeUserFromBatch(userId, batchId);
+      const result = await runAction(() => removeUserFromBatch(userId, batchId), toast.error);
+      if (!result) return;
 
       if (result.success) {
         refreshCurrentScope();
@@ -525,7 +567,8 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     if (!confirm(`Cancel invite for ${userName} in ${batchName}? They will need to be re-invited.`)) return;
 
     startTransition(async () => {
-      const result = await cancelInvite(userId, batchId);
+      const result = await runAction(() => cancelInvite(userId, batchId), toast.error);
+      if (!result) return;
 
       if (result.success) {
         refreshCurrentScope();
@@ -538,7 +581,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const handleResendInvite = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await resendInvite(userId, batchId);
+      const result = await runAction(() => resendInvite(userId, batchId), toast.error);
+      if (!result) return;
+
       if (result.success) {
         if (result.warning) {
           toast.warning(result.warning);
@@ -557,7 +602,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     if (!confirm(`Deactivate ${userName}? They will no longer be able to sign in.`)) return;
 
     startTransition(async () => {
-      const result = await deactivateUser(userId, batchId);
+      const result = await runAction(() => deactivateUser(userId, batchId), toast.error);
+      if (!result) return;
+
       if (result.success) {
         toast.success("User deactivated");
         refreshCurrentScope();
@@ -570,7 +617,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const handleReactivateUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await reactivateUser(userId, batchId);
+      const result = await runAction(() => reactivateUser(userId, batchId), toast.error);
+      if (!result) return;
+
       if (result.success) {
         toast.success("User reactivated");
         refreshCurrentScope();
@@ -585,7 +634,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     if (!confirm(`Mark ${userName} as dropped out from ${batchName}? They will lose access to this batch but remain active in other batches.`)) return;
 
     startTransition(async () => {
-      const result = await dropoutUserFromBatch(userId, batchId);
+      const result = await runAction(() => dropoutUserFromBatch(userId, batchId), toast.error);
+      if (!result) return;
+
       if (result.success) {
         toast.success("User dropped out from batch");
         refreshCurrentScope();
@@ -598,7 +649,9 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
 
   const handleRestoreBatchUser = async (userId: string, batchId: string) => {
     startTransition(async () => {
-      const result = await restoreUserBatch(userId, batchId);
+      const result = await runAction(() => restoreUserBatch(userId, batchId), toast.error);
+      if (!result) return;
+
       if (result.success) {
         toast.success("Batch membership restored");
         refreshCurrentScope();
@@ -633,10 +686,16 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
     }
     setNotifEmailError("");
     startTransition(async () => {
-      const result = await updateUserNotificationEmail(
-        editNotifEmail.userId,
-        trimmed.length > 0 ? trimmed : null
+      const result = await runAction(
+        () =>
+          updateUserNotificationEmail(
+            editNotifEmail.userId,
+            trimmed.length > 0 ? trimmed : null
+          ),
+        setNotifEmailError
       );
+      if (!result) return;
+
       if (result.success) {
         toast.success(trimmed.length > 0 ? "Notification email updated" : "Notification email cleared");
         setEditNotifEmail(null);
@@ -1253,6 +1312,8 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
         {bulkResults ? (() => {
           const successCount = bulkResults.filter((r) => r.success).length;
           const failCount = bulkResults.filter((r) => !r.success).length;
+          const mailedCount = bulkResults.filter((r) => r.success && r.emailSent).length;
+          const notMailedCount = successCount - mailedCount;
           return (
             <div className="space-y-4">
               {/* Summary cards */}
@@ -1266,8 +1327,20 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                     border: "1px solid rgba(34, 197, 94, 0.2)",
                   }}
                 >
-                  <div style={{ fontSize: "24px", fontWeight: 600, color: "#16a34a" }}>{successCount}</div>
-                  <div style={{ fontSize: "13px", color: "var(--color-foreground-secondary)" }}>Invited</div>
+                  <div style={{ fontSize: "24px", fontWeight: 600, color: "#16a34a" }}>{mailedCount}</div>
+                  <div style={{ fontSize: "13px", color: "var(--color-foreground-secondary)" }}>Email sent</div>
+                </div>
+                <div
+                  style={{
+                    flex: 1,
+                    padding: "12px 16px",
+                    borderRadius: "8px",
+                    backgroundColor: notMailedCount > 0 ? "rgba(245, 158, 11, 0.10)" : "rgba(0,0,0,0.02)",
+                    border: notMailedCount > 0 ? "1px solid rgba(245, 158, 11, 0.25)" : "1px solid var(--color-card-border)",
+                  }}
+                >
+                  <div style={{ fontSize: "24px", fontWeight: 600, color: notMailedCount > 0 ? "#b45309" : "var(--color-foreground-secondary)" }}>{notMailedCount}</div>
+                  <div style={{ fontSize: "13px", color: "var(--color-foreground-secondary)" }}>No email</div>
                 </div>
                 <div
                   style={{
@@ -1279,9 +1352,24 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                   }}
                 >
                   <div style={{ fontSize: "24px", fontWeight: 600, color: failCount > 0 ? "#dc2626" : "var(--color-foreground-secondary)" }}>{failCount}</div>
-                  <div style={{ fontSize: "13px", color: "var(--color-foreground-secondary)" }}>Skipped</div>
+                  <div style={{ fontSize: "13px", color: "var(--color-foreground-secondary)" }}>Failed</div>
                 </div>
               </div>
+
+              {notMailedCount > 0 && (
+                <div
+                  className="p-3 rounded-lg text-sm"
+                  style={{
+                    backgroundColor: "rgba(245, 158, 11, 0.10)",
+                    border: "1px solid rgba(245, 158, 11, 0.25)",
+                    color: "#92400e",
+                  }}
+                >
+                  {notMailedCount} {notMailedCount === 1 ? "person was" : "people were"} added to the
+                  batch but received no invitation email. See the reason on each row — where an
+                  invite link is shown, send it to them manually.
+                </div>
+              )}
 
               {/* Per-email results */}
               <div
@@ -1292,31 +1380,61 @@ export function UserManagement({ batches, canAssignSuperAdmin }: UserManagementP
                   border: "1px solid var(--color-card-border)",
                 }}
               >
-                {bulkResults.map((r, i) => (
-                  <div
-                    key={i}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "8px",
-                      padding: "10px 12px",
-                      fontSize: "14px",
-                      borderBottom: i < bulkResults.length - 1 ? "1px solid var(--color-card-border)" : "none",
-                    }}
-                  >
-                    <span style={{ color: r.success ? "#16a34a" : "#dc2626", flexShrink: 0 }}>
-                      {r.success ? "\u2713" : "\u2717"}
-                    </span>
-                    <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                      {r.email}
-                    </span>
-                    {r.error && (
-                      <span style={{ fontSize: "12px", color: "#dc2626", flexShrink: 0 }}>
-                        {r.error}
-                      </span>
-                    )}
-                  </div>
-                ))}
+                {bulkResults.map((r, i) => {
+                  const mailed = r.success && r.emailSent;
+                  const statusColor = !r.success ? "#dc2626" : mailed ? "#16a34a" : "#b45309";
+                  const statusMark = !r.success ? "\u2717" : mailed ? "\u2713" : "!";
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        padding: "10px 12px",
+                        fontSize: "14px",
+                        borderBottom: i < bulkResults.length - 1 ? "1px solid var(--color-card-border)" : "none",
+                      }}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                        <span style={{ color: statusColor, flexShrink: 0, fontWeight: 600 }}>
+                          {statusMark}
+                        </span>
+                        <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {r.email}
+                        </span>
+                        {r.error && (
+                          <span style={{ fontSize: "12px", color: "#dc2626", flexShrink: 0 }}>
+                            {r.error}
+                          </span>
+                        )}
+                        {r.success && !mailed && r.inviteLink && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              navigator.clipboard.writeText(r.inviteLink || "");
+                              toast.success("Invite link copied");
+                            }}
+                            style={{
+                              flexShrink: 0,
+                              fontSize: "12px",
+                              padding: "4px 10px",
+                              borderRadius: "6px",
+                              border: "1px solid var(--color-card-border)",
+                              background: "none",
+                              cursor: "pointer",
+                              color: "var(--color-foreground-secondary)",
+                            }}
+                          >
+                            Copy link
+                          </button>
+                        )}
+                      </div>
+                      {r.success && !mailed && r.note && (
+                        <div style={{ fontSize: "12px", color: "#b45309", marginLeft: "20px", marginTop: "2px" }}>
+                          {r.note}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
 
               {/* Action buttons */}

--- a/founder-sprint/src/lib/email.ts
+++ b/founder-sprint/src/lib/email.ts
@@ -12,6 +12,18 @@ const transporter =
       })
     : null;
 
+/**
+ * Result of an email send attempt.
+ *
+ * `skipped: true` means nothing was handed to the SMTP server — the recipient
+ * was filtered out as undeliverable. Callers must not report this as "sent".
+ */
+export type EmailResult = {
+  success: boolean;
+  error?: string;
+  skipped?: boolean;
+};
+
 function hasUndeliverableRecipient(to: string | string[]): boolean {
   const addresses = Array.isArray(to) ? to : [to];
   return addresses.some((addr) => addr.endsWith("@example.com"));
@@ -31,12 +43,12 @@ export async function sendInvitationEmail({
   batchName,
   role,
   inviteLink,
-}: InvitationEmailParams): Promise<{ success: boolean; error?: string }> {
+}: InvitationEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   const roleDisplayName = {
     admin: "Admin",
@@ -122,12 +134,12 @@ export async function sendBatchOnboardingDigestEmail({
   assignmentsUrl,
   sessionsUrl,
   eventsUrl,
-}: BatchOnboardingDigestEmailParams): Promise<{ success: boolean; error?: string }> {
+}: BatchOnboardingDigestEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -192,12 +204,12 @@ export async function sendOfficeHourRequestEmail({
   endTime,
   agenda,
   message,
-}: OfficeHourRequestEmailParams): Promise<{ success: boolean; error?: string }> {
+}: OfficeHourRequestEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   const dateTimeStr = displayRangeInUserTimezone(startTime, endTime, null, "UTC");
 
@@ -295,12 +307,12 @@ export async function sendAssignmentPublishedEmail({
   assignmentTitle,
   dueDate,
   assignmentUrl,
-}: AssignmentPublishedEmailParams): Promise<{ success: boolean; error?: string }> {
+}: AssignmentPublishedEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -349,12 +361,12 @@ export async function sendAssignmentFeedbackEmail({
   feedbackContent,
   submissionUrl,
   isReply = false,
-}: AssignmentFeedbackEmailParams): Promise<{ success: boolean; error?: string }> {
+}: AssignmentFeedbackEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -396,12 +408,12 @@ export async function sendOfficeHourApprovalEmail({
   endTime,
   meetLink,
   companyName,
-}: OfficeHourApprovalEmailParams): Promise<{ success: boolean; error?: string }> {
+}: OfficeHourApprovalEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   const dateTimeStr = displayRangeInUserTimezone(startTime, endTime, null, "UTC");
 
@@ -461,12 +473,12 @@ export async function sendAssignmentDeadlineReminderEmail({
   assignmentTitle,
   dueDate,
   assignmentUrl,
-}: AssignmentDeadlineReminderEmailParams): Promise<{ success: boolean; error?: string }> {
+}: AssignmentDeadlineReminderEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -504,12 +516,12 @@ export async function sendSubmissionCompletedEmail({
   founderName,
   assignmentTitle,
   submissionUrl,
-}: SubmissionCompletedEmailParams): Promise<{ success: boolean; error?: string }> {
+}: SubmissionCompletedEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -546,12 +558,12 @@ export async function sendFeedMentionEmail({
   authorName,
   postExcerpt,
   postUrl,
-}: FeedMentionEmailParams): Promise<{ success: boolean; error?: string }> {
+}: FeedMentionEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({
@@ -592,12 +604,12 @@ export async function sendFeedReplyNotificationEmail({
   replierName,
   replyContent,
   postUrl,
-}: FeedReplyNotificationEmailParams): Promise<{ success: boolean; error?: string }> {
+}: FeedReplyNotificationEmailParams): Promise<EmailResult> {
   if (!transporter) {
     console.warn("Email not configured - GMAIL_USER or GMAIL_APP_PASSWORD missing");
     return { success: false, error: "Email service not configured" };
   }
-  if (hasUndeliverableRecipient(to)) return { success: true };
+  if (hasUndeliverableRecipient(to)) return { success: true, skipped: true };
 
   try {
     await transporter.sendMail({

--- a/founder-sprint/src/types/index.ts
+++ b/founder-sprint/src/types/index.ts
@@ -40,6 +40,23 @@ export type ActionResult<T = void> =
   | { success: true; data: T; warning?: string }
   | { success: false; error: string };
 
+/**
+ * One row of a bulk invite report.
+ *
+ * `success` only means the membership was created — it says nothing about mail
+ * delivery. Read `emailSent` for that, and show `note` to explain a row that
+ * succeeded without an email going out.
+ */
+export type BulkInviteRow = {
+  email: string;
+  success: boolean;
+  error?: string;
+  inviteLink?: string;
+  membershipStatus?: "active" | "invited";
+  emailSent?: boolean;
+  note?: string;
+};
+
 // Pagination
 export interface PaginationParams {
   page: number;


### PR DESCRIPTION
Bulk invite reported every created membership as a green "Invited" row, even when no email left the server. Three paths were silently swallowed:

- @example.com recipients were filtered out but returned {success: true}, so callers could not tell "skipped" from "sent".
- bulkInviteUsers and inviteBatchMembersFromSource dropped the per-item warning from inviteUserCore, hiding SMTP failures that the single-invite flow surfaces as a toast.
- Direct activation of an existing user sends no invite email by design, but was still counted as invited.

Introduce EmailResult.skipped and InviteOutcome.emailSent so "membership created" and "mail actually sent" are separate facts, propagate them through both bulk paths, and split the results view into Email sent / No email / Failed with a per-row reason and a copy-link affordance.

Also route invite mail through getRecipientEmail() in inviteUserCore and resendInvite, matching the ten other send sites that already honour User.notificationEmail.

Finally, wrap every server action call in UserManagement behind runAction so a rejected action reports an error instead of leaving the UI frozen with no toast, no spinner change, and no state update.